### PR TITLE
Update build-image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,43 +2,15 @@ name: Build Operator Image
 
 on:
   pull_request_target:
-    types: [opened, synchronize, closed]
+    types: [closed]
 
 permissions:
   actions: write
   contents: read
 
 jobs:
-  build-pr-image:
-    if: github.event.action == 'opened'|| github.event.action == 'synchronize'
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Set up Go 1.21
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.21'
-          
-      - name: Checkout PR branch
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Log current commit
-        run: echo "Building image from commit ${{ github.event.pull_request.head.sha }}"
-
-      - name: Login to Quay.io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.APP_QUAY_USERNAME }}
-          password: ${{ secrets.APP_QUAY_TOKEN }}
-
-      - name: Build and push PR image
-        run: |
-          make docker-build docker-push -e IMG=quay.io/opendatahub/llama-stack-k8s-operator:pr-${{ github.event.number }}
-
   build-latest-image:
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Go 1.21


### PR DESCRIPTION
This commit removes build and push of PR images. It only pushes the image once the code is approved and merged