### PR TITLE
Add e2e tests for the controller

### DIFF
--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -1,0 +1,88 @@
+name: Run E2E Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [ main ]
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create kind config
+        run: |
+          cat > kind-config.yaml << EOF
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          containerdConfigPatches:
+          - |-
+            [plugins."io.containerd.grpc.v1.cri".registry]
+              config_path = "/etc/containerd/certs.d"
+          nodes:
+          - role: control-plane
+            kubeadmConfigPatches:
+            - |
+              kind: InitConfiguration
+              nodeRegistration:
+                kubeletExtraArgs:
+                  system-reserved: memory=500Mi
+                  eviction-hard: memory.available<200Mi
+            extraPortMappings:
+            - containerPort: 80
+              hostPort: 80
+              protocol: TCP
+            - containerPort: 443
+              hostPort: 443
+              protocol: TCP
+          EOF
+
+      - name: Create k8s Kind Cluster
+        id: kind
+        uses: helm/kind-action@v1
+        with:
+          registry: true
+          registry_name: kind-registry
+          registry_port: 5000
+          registry_enable_delete: true
+          config: kind-config.yaml
+
+      - name: Build operator image
+        run: |
+          # Build the image with a simpler tag format
+          docker build -t kind-registry:5000/llama-stack-k8s-operator:pr${{ github.event.pull_request.number }} -f Dockerfile .
+
+          # Tag the image for local registry
+          docker tag kind-registry:5000/llama-stack-k8s-operator:pr${{ github.event.pull_request.number }} kind-registry:5000/llama-stack-k8s-operator:latest
+
+      - name: Push operator image to local registry
+        run: |
+          docker push kind-registry:5000/llama-stack-k8s-operator:latest
+
+      - name: Deploy operator
+        run: |
+          # Deploy the operator
+          make deploy IMG=kind-registry:5000/llama-stack-k8s-operator:latest
+
+          # Wait for operator deployment to be ready
+          if ! kubectl wait --for=condition=available --timeout=300s deployment/llama-stack-k8s-operator-controller-manager -n llama-stack-k8s-operator-system; then
+            echo "Deployment failed to become ready. Debugging information:"
+            kubectl describe deployment llama-stack-k8s-operator-controller-manager -n llama-stack-k8s-operator-system
+            kubectl logs -l control-plane=controller-manager -n llama-stack-k8s-operator-system --tail=100
+            kubectl get events -n llama-stack-k8s-operator-system --sort-by='.lastTimestamp'
+            exit 1
+          fi
+
+      - name: Run e2e tests
+        run: |
+          make e2e-tests

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repo hosts a kubernetes operator that is responsible for creating and manag
     - [Build Image](#build-image)
     - [Deployment](#deployment)
 - [Deploying Llama Stack Server](#deploying-the-llama-stack-server)
+- [Running E2E Tests](#running-e2e-tests)
 
 
 ## Developer Guide
@@ -82,3 +83,20 @@ spec:
         mountPath: "/root/.llama"
 ```
 3. Verify the server pod is running in the user define namespace.
+
+### Running E2E Tests
+
+The operator includes end-to-end (E2E) tests to verify the complete functionality of the operator. To run the E2E tests:
+
+1. Ensure you have a running Kubernetes cluster
+2. Run the E2E tests using one of the following commands:
+   - If you want to deploy the operator and run tests:
+     ```commandline
+     make deploy e2e-tests
+     ```
+   - If the operator is already deployed:
+     ```commandline
+     make e2e-tests
+     ```
+
+The make target will handle prerequisites including deploying ollama server.

--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -110,6 +110,10 @@ func (r *LlamaStackDistributionReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
 	}
 
+	if !instance.Status.Ready {
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
 	r.Log.Info("Successfully reconciled LlamaStackDistribution")
 	return ctrl.Result{}, nil
 }
@@ -371,6 +375,7 @@ func (r *LlamaStackDistributionReconciler) updateStatus(ctx context.Context, ins
 	if err := r.Status().Update(ctx, instance); err != nil {
 		return fmt.Errorf("failed to update status: %w", err)
 	}
+
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,15 @@ require (
 	github.com/go-logr/logr v1.4.1
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
+	github.com/stretchr/testify v1.8.4
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.2
+	k8s.io/apiextensions-apiserver v0.29.0
 	k8s.io/apimachinery v0.29.2
 	k8s.io/client-go v0.29.2
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.17.2
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -43,6 +46,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
@@ -63,11 +67,9 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apiextensions-apiserver v0.29.0 // indirect
 	k8s.io/component-base v0.29.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/hack/deploy-ollama.sh
+++ b/hack/deploy-ollama.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -e
+
+OLLAMA_IMAGE=${1:-"ollama/ollama:latest"}
+
+echo "Checking if namespace ollama-dist exists..."
+if ! kubectl get namespace ollama-dist &> /dev/null; then
+    echo "Creating namespace ollama-dist..."
+    kubectl create namespace ollama-dist
+else
+    echo "Namespace ollama-dist already exists"
+fi
+
+echo "Creating ServiceAccount..."
+if ! kubectl get sa llama-sa -n ollama-dist &> /dev/null; then
+    echo "Creating ServiceAccount llama-sa..."
+    kubectl create sa llama-sa -n ollama-dist
+else
+    echo "ServiceAccount llama-sa already exists"
+fi
+
+echo "Creating Ollama deployment and service with image: $OLLAMA_IMAGE..."
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama-server
+  namespace: ollama-dist
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollama-server
+  template:
+    metadata:
+      labels:
+        app: ollama-server
+    spec:
+      serviceAccountName: llama-sa
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+      containers:
+      - name: ollama-server
+        image: ${OLLAMA_IMAGE}
+        args: ["serve"]
+        ports:
+        - containerPort: 11434
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+        securityContext:
+          allowPrivilegeEscalation: true
+          runAsNonRoot: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama-server-service
+  namespace: ollama-dist
+spec:
+  selector:
+    app: ollama-server
+  ports:
+  - protocol: TCP
+    port: 11434
+    targetPort: 11434
+  type: ClusterIP
+EOF
+
+echo "Waiting for Ollama deployment to be ready..."
+kubectl rollout status deployment/ollama-server -n ollama-dist
+
+POD_NAME=$(kubectl get pods -n ollama-dist -l app=ollama-server -o name |  head -n1)
+
+echo "Running llama3.2:1b model..."
+kubectl exec -n ollama-dist $POD_NAME -- ollama run llama3.2:1b --keepalive 60m

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -1,0 +1,181 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/meta-llama/llama-stack-k8s-operator/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestCreationSuite(t *testing.T) {
+	if TestOpts.SkipCreation {
+		t.Skip("Skipping creation test suite")
+	}
+
+	var distribution *v1alpha1.LlamaStackDistribution
+
+	t.Run("should create LlamaStackDistribution", func(t *testing.T) {
+		distribution = testCreateDistribution(t)
+	})
+
+	t.Run("should handle direct deployment updates", func(t *testing.T) {
+		testDirectDeploymentUpdates(t, distribution)
+	})
+
+	t.Run("should check health status", func(t *testing.T) {
+		testHealthStatus(t, distribution)
+	})
+
+	t.Run("should update deployment through CR", func(t *testing.T) {
+		testCRDeploymentUpdate(t, distribution)
+	})
+}
+
+func testCreateDistribution(t *testing.T) *v1alpha1.LlamaStackDistribution {
+	t.Helper()
+	// Create test namespace
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "llama-stack-test",
+		},
+	}
+	err := TestEnv.Client.Create(TestEnv.Ctx, ns)
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		require.NoError(t, err)
+	}
+
+	// Get sample CR
+	distribution := GetSampleCR(t)
+	distribution.Namespace = ns.Name
+
+	err = TestEnv.Client.Create(TestEnv.Ctx, distribution)
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		require.NoError(t, err)
+	}
+
+	// Wait for deployment to be ready
+	err = EnsureResourceReady(t, TestEnv, schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
+	}, distribution.Name, ns.Name, ResourceReadyTimeout, isDeploymentReady)
+	require.NoError(t, err)
+
+	// Verify service is created
+	err = EnsureResourceReady(t, TestEnv, schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Service",
+	}, distribution.Name+"-service", ns.Name, ResourceReadyTimeout, func(u *unstructured.Unstructured) bool {
+		// Check if the service has a valid spec and status
+		spec, specFound, _ := unstructured.NestedMap(u.Object, "spec")
+		status, statusFound, _ := unstructured.NestedMap(u.Object, "status")
+		return specFound && statusFound && spec != nil && status != nil
+	})
+	require.NoError(t, err)
+
+	return distribution
+}
+
+func testDirectDeploymentUpdates(t *testing.T, distribution *v1alpha1.LlamaStackDistribution) {
+	t.Helper()
+	// Get the deployment
+	deployment := &appsv1.Deployment{}
+	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
+		Namespace: distribution.Namespace,
+		Name:      distribution.Name,
+	}, deployment)
+	require.NoError(t, err)
+
+	originalReplicas := *deployment.Spec.Replicas
+	*deployment.Spec.Replicas = 2
+	err = TestEnv.Client.Update(TestEnv.Ctx, deployment)
+	require.NoError(t, err)
+
+	// Wait for operator to reconcile
+	time.Sleep(5 * time.Second)
+
+	// Verify deployment is reverted to original state
+	err = TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
+		Namespace: distribution.Namespace,
+		Name:      distribution.Name,
+	}, deployment)
+	require.NoError(t, err)
+	require.Equal(t, originalReplicas, *deployment.Spec.Replicas, "Deployment should be reverted to original state")
+}
+
+func testCRDeploymentUpdate(t *testing.T, distribution *v1alpha1.LlamaStackDistribution) {
+	t.Helper()
+	// Update CR
+	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
+		Namespace: distribution.Namespace,
+		Name:      distribution.Name,
+	}, distribution)
+	require.NoError(t, err)
+
+	// Update replicas
+	distribution.Spec.Replicas = 2
+	err = TestEnv.Client.Update(TestEnv.Ctx, distribution)
+	require.NoError(t, err)
+
+	// Wait for deployment to be updated and ready with new replicas
+	err = EnsureResourceReady(t, TestEnv, schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
+	}, distribution.Name, distribution.Namespace, ResourceReadyTimeout, func(u *unstructured.Unstructured) bool {
+		availableReplicas, found, nestedErr := unstructured.NestedInt64(u.Object, "status", "availableReplicas")
+		if !found || nestedErr != nil {
+			return false
+		}
+		return availableReplicas == 2
+	})
+	require.NoError(t, err, "Failed to wait for deployment to update replicas")
+
+	// Verify deployment is updated
+	deployment := &appsv1.Deployment{}
+	err = TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
+		Namespace: distribution.Namespace,
+		Name:      distribution.Name,
+	}, deployment)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), deployment.Status.AvailableReplicas, "Deployment should have 2 available replicas")
+}
+
+func testHealthStatus(t *testing.T, distribution *v1alpha1.LlamaStackDistribution) {
+	t.Helper()
+	// Wait for status to be updated with a longer interval to avoid rate limiting
+	err := wait.PollUntilContextTimeout(TestEnv.Ctx, 1*time.Minute, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		// Get the latest state of the distribution
+		updatedDistribution := &v1alpha1.LlamaStackDistribution{}
+		err := TestEnv.Client.Get(ctx, client.ObjectKey{
+			Namespace: distribution.Namespace,
+			Name:      distribution.Name,
+		}, updatedDistribution)
+		if err != nil {
+			return false, err
+		}
+		return updatedDistribution.Status.Ready, nil
+	})
+	require.NoError(t, err, "Failed to wait for distribution status update")
+}
+
+func isDeploymentReady(u *unstructured.Unstructured) bool {
+	replicas, found, err := unstructured.NestedInt64(u.Object, "status", "replicas")
+	if !found || err != nil {
+		return false
+	}
+	availableReplicas, found, err := unstructured.NestedInt64(u.Object, "status", "availableReplicas")
+	return found && err == nil && availableReplicas == replicas
+}

--- a/tests/e2e/deletion_test.go
+++ b/tests/e2e/deletion_test.go
@@ -1,0 +1,72 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"testing"
+
+	"github.com/meta-llama/llama-stack-k8s-operator/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestDeletionSuite(t *testing.T) {
+	if TestOpts.SkipDeletion {
+		t.Skip("Skipping deletion test suite")
+	}
+
+	t.Run("should delete LlamaStackDistribution CR and cleanup resources", func(t *testing.T) {
+		instance := &v1alpha1.LlamaStackDistribution{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "llamastackdistribution-sample",
+				Namespace: "llama-stack-test",
+			},
+		}
+
+		// Delete the instance
+		err := TestEnv.Client.Delete(TestEnv.Ctx, instance)
+		require.NoError(t, err)
+
+		// Wait for deployment to be deleted
+		err = EnsureResourceDeleted(t, TestEnv, schema.GroupVersionKind{
+			Group:   "apps",
+			Version: "v1",
+			Kind:    "Deployment",
+		}, instance.Name, instance.Namespace, ResourceReadyTimeout)
+		require.NoError(t, err, "Deployment should be deleted")
+
+		// Wait for service to be deleted
+		err = EnsureResourceDeleted(t, TestEnv, schema.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Service",
+		}, instance.Name+"-service", instance.Namespace, ResourceReadyTimeout)
+		require.NoError(t, err, "Service should be deleted")
+
+		// Wait for CR to be deleted
+		err = EnsureResourceDeleted(t, TestEnv, schema.GroupVersionKind{
+			Group:   "llama.x-k8s.io",
+			Version: "v1alpha1",
+			Kind:    "LlamaStackDistribution",
+		}, instance.Name, instance.Namespace, ResourceReadyTimeout)
+		require.NoError(t, err, "CR should be deleted")
+
+		// Verify no orphaned resources
+		podList := &corev1.PodList{}
+		err = TestEnv.Client.List(TestEnv.Ctx, podList, client.InNamespace(instance.Namespace))
+		require.NoError(t, err)
+		for _, pod := range podList.Items {
+			require.NotEqual(t, instance.Name, pod.Labels["app"], "Found orphaned pod")
+		}
+
+		// Verify no orphaned configmaps
+		configMapList := &corev1.ConfigMapList{}
+		err = TestEnv.Client.List(TestEnv.Ctx, configMapList, client.InNamespace(instance.Namespace))
+		require.NoError(t, err)
+		for _, cm := range configMapList.Items {
+			require.NotEqual(t, instance.Name, cm.Labels["app"], "Found orphaned configmap")
+		}
+	})
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,0 +1,18 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"testing"
+)
+
+func TestE2E(t *testing.T) {
+	registerSchemes()
+	// Run validation tests
+	t.Run("validation", TestValidationSuite)
+
+	// // Run creation tests
+	t.Run("creation", TestCreationSuite)
+
+	// Run deletion tests if not skipped
+	t.Run("deletion", TestDeletionSuite)
+}

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -1,0 +1,28 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"os"
+	"testing"
+)
+
+var (
+	TestEnv *TestEnvironment
+)
+
+func TestMain(m *testing.M) {
+	// Set up test environment
+	var err error
+	TestEnv, err = SetupTestEnv()
+	if err != nil {
+		os.Exit(1)
+	}
+
+	// Run tests
+	code := m.Run()
+
+	// Clean up test environment
+	CleanupTestEnv(TestEnv)
+
+	os.Exit(code)
+}

--- a/tests/e2e/test_options.go
+++ b/tests/e2e/test_options.go
@@ -1,0 +1,33 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"fmt"
+)
+
+// TestOptions defines the configuration for running tests.
+type TestOptions struct {
+	SkipValidation bool
+	SkipCreation   bool
+	SkipDeletion   bool
+	OperatorNS     string
+}
+
+// TestOpts is the global test options instance.
+var TestOpts = NewTestOptions()
+
+// NewTestOptions creates a new TestOptions instance with default values.
+func NewTestOptions() *TestOptions {
+	return &TestOptions{
+		SkipValidation: false,
+		SkipCreation:   false,
+		SkipDeletion:   false,
+		OperatorNS:     "llama-stack-k8s-operator-system",
+	}
+}
+
+// String returns a string representation of the test options.
+func (o *TestOptions) String() string {
+	return fmt.Sprintf("SkipValidation: %v, SkipCreation: %v, SkipDeletion: %v, OperatorNS: %s",
+		o.SkipValidation, o.SkipCreation, o.SkipDeletion, o.OperatorNS)
+}

--- a/tests/e2e/test_utils.go
+++ b/tests/e2e/test_utils.go
@@ -1,0 +1,184 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/meta-llama/llama-stack-k8s-operator/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	ollamaNS             = "ollama-dist"
+	pollInterval         = 10 * time.Second
+	ResourceReadyTimeout = 2 * time.Minute
+	generalRetryInterval = 5 * time.Second
+)
+
+var (
+	Scheme = runtime.NewScheme()
+)
+
+// TestEnvironment holds the test environment configuration.
+type TestEnvironment struct {
+	Client client.Client
+	Ctx    context.Context //nolint:containedctx // Context is used for test environment
+}
+
+// SetupTestEnv sets up the test environment.
+func SetupTestEnv() (*TestEnvironment, error) {
+	// Get a config to talk to the apiserver
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new client
+	cl, err := client.New(cfg, client.Options{Scheme: Scheme})
+	if err != nil {
+		return nil, err
+	}
+
+	return &TestEnvironment{
+		Client: cl,
+		Ctx:    context.TODO(),
+	}, nil
+}
+
+// validateCRD checks if a CustomResourceDefinition is established.
+func validateCRD(c client.Client, ctx context.Context, crdName string) error {
+	crd := &apiextv1.CustomResourceDefinition{}
+	obj := client.ObjectKey{
+		Name: crdName,
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, generalRetryInterval, ResourceReadyTimeout, true, func(ctx context.Context) (bool, error) {
+		err := c.Get(ctx, obj, crd)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			log.Printf("Failed to get CRD %s", crdName)
+			return false, err
+		}
+
+		for _, condition := range crd.Status.Conditions {
+			if condition.Type == apiextv1.Established {
+				if condition.Status == apiextv1.ConditionTrue {
+					return true, nil
+				}
+			}
+		}
+		log.Printf("Error to get CRD %s condition's matching", crdName)
+		return false, nil
+	})
+
+	return err
+}
+
+// GetDeployment gets a deployment by name and namespace.
+func GetDeployment(cl client.Client, ctx context.Context, name, namespace string) (*appsv1.Deployment, error) {
+	deployment := &appsv1.Deployment{}
+	err := cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, deployment)
+	return deployment, err
+}
+
+// EnsureResourceReady polls until the resource is ready.
+func EnsureResourceReady(
+	t *testing.T,
+	testenv *TestEnvironment,
+	gvk schema.GroupVersionKind,
+	name, namespace string,
+	timeout time.Duration,
+	isReady func(*unstructured.Unstructured) bool,
+) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(testenv.Ctx, timeout)
+	defer cancel()
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		err := testenv.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return isReady(obj), nil
+	})
+}
+
+// EnsureResourceDeleted polls until the resource is deleted.
+func EnsureResourceDeleted(t *testing.T, testenv *TestEnvironment, gvk schema.GroupVersionKind, name, namespace string, timeout time.Duration) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(testenv.Ctx, timeout)
+	defer cancel()
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		err := testenv.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj)
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+// CleanupTestEnv cleans up the test environment.
+func CleanupTestEnv(env *TestEnvironment) {
+	// Implementation will be added later
+}
+
+// registerSchemes registers all necessary schemes for testing.
+func registerSchemes() {
+	schemes := []func(*runtime.Scheme) error{
+		clientgoscheme.AddToScheme,
+		apiextv1.AddToScheme,
+		v1alpha1.AddToScheme,
+	}
+
+	for _, schemeFn := range schemes {
+		utilruntime.Must(schemeFn(Scheme))
+	}
+}
+
+// GetSampleCR returns a LlamaStackDistribution from the sample YAML file.
+func GetSampleCR(t *testing.T) *v1alpha1.LlamaStackDistribution {
+	t.Helper()
+	// Get the absolute path of the project root
+	projectRoot, err := filepath.Abs("../..")
+	require.NoError(t, err)
+
+	// Construct the path to the sample file
+	samplePath := filepath.Join(projectRoot, "config", "samples", "_v1alpha1_llamastackdistribution.yaml")
+
+	// Read the sample file
+	yamlFile, err := os.ReadFile(samplePath)
+	require.NoError(t, err)
+
+	// Create and unmarshal the distribution
+	distribution := &v1alpha1.LlamaStackDistribution{}
+	err = yaml.Unmarshal(yamlFile, distribution)
+	require.NoError(t, err)
+
+	return distribution
+}

--- a/tests/e2e/validation_test.go
+++ b/tests/e2e/validation_test.go
@@ -1,0 +1,55 @@
+//nolint:testpackage
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestValidationSuite(t *testing.T) {
+	if TestOpts.SkipValidation {
+		t.Skip("Skipping validation test suite")
+	}
+
+	t.Run("should validate CRDs", func(t *testing.T) {
+		err := validateCRD(TestEnv.Client, TestEnv.Ctx, "llamastackdistributions.llama.x-k8s.io")
+		require.NoErrorf(t, err, "error in validating CRD: llamastackdistributions.llama.x-k8s.io")
+	})
+
+	t.Run("should validate operator deployment", func(t *testing.T) {
+		deployment, err := GetDeployment(TestEnv.Client, TestEnv.Ctx, "llama-stack-k8s-operator-controller-manager", TestOpts.OperatorNS)
+		require.NoError(t, err, "Operator deployment not found")
+		require.Equal(t, int32(1), deployment.Status.ReadyReplicas, "Operator deployment not ready")
+	})
+
+	t.Run("should validate operator pods", func(t *testing.T) {
+		podList := &corev1.PodList{}
+		err := TestEnv.Client.List(TestEnv.Ctx, podList, client.InNamespace(TestOpts.OperatorNS))
+		require.NoError(t, err)
+
+		operatorPodFound := false
+		for _, pod := range podList.Items {
+			if pod.Labels["app.kubernetes.io/name"] == "llama-stack-k8s-operator" {
+				operatorPodFound = true
+				require.Equal(t, corev1.PodRunning, pod.Status.Phase)
+				break
+			}
+		}
+		require.True(t, operatorPodFound, "Operator pod not found in namespace %s", TestOpts.OperatorNS)
+	})
+
+	t.Run("should validate prerequisites", func(t *testing.T) {
+		deployment, err := GetDeployment(TestEnv.Client, TestEnv.Ctx, "ollama-server", ollamaNS)
+		require.NoError(t, err, "Ollama deployment not found")
+		require.Equal(t, int32(1), deployment.Status.ReadyReplicas, "Ollama deployment not ready")
+
+		podList := &corev1.PodList{}
+		err = TestEnv.Client.List(TestEnv.Ctx, podList, client.InNamespace(ollamaNS))
+		require.NoError(t, err)
+		require.NotEmpty(t, podList.Items, "No Ollama pods found")
+		require.Equal(t, corev1.PodRunning, podList.Items[0].Status.Phase, "Ollama pod not running")
+	})
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces e2e testing package for controller
## How Has This Been Tested?
1. `make deploy e2e-tests`
2. Expected test results:
```
=== RUN   TestE2E
=== RUN   TestE2E/validation
=== RUN   TestE2E/validation/should_validate_CRDs
=== RUN   TestE2E/validation/should_validate_operator_deployment
=== RUN   TestE2E/validation/should_validate_operator_pods
=== RUN   TestE2E/validation/should_validate_prerequisites
=== RUN   TestE2E/creation
=== RUN   TestE2E/creation/should_create_LlamaStackDistribution
=== RUN   TestE2E/creation/should_handle_direct_deployment_updates
=== RUN   TestE2E/creation/should_update_deployment_through_CR
=== RUN   TestE2E/creation/should_check_health_status
=== RUN   TestE2E/deletion
=== RUN   TestE2E/deletion/should_delete_LlamaStackDistribution_CR_and_cleanup_resources
--- PASS: TestE2E (45.67s)
    --- PASS: TestE2E/validation (5.16s)
        --- PASS: TestE2E/validation/should_validate_CRDs (5.07s)
        --- PASS: TestE2E/validation/should_validate_operator_deployment (0.03s)
        --- PASS: TestE2E/validation/should_validate_operator_pods (0.02s)
        --- PASS: TestE2E/validation/should_validate_prerequisites (0.05s)
    --- PASS: TestE2E/creation (40.35s)
        --- PASS: TestE2E/creation/should_create_LlamaStackDistribution (20.12s)
        --- PASS: TestE2E/creation/should_handle_direct_deployment_updates (5.09s)
        --- PASS: TestE2E/creation/should_update_deployment_through_CR (10.11s)
        --- PASS: TestE2E/creation/should_check_health_status (5.03s)
    --- PASS: TestE2E/deletion (0.15s)
        --- PASS: TestE2E/deletion/should_delete_LlamaStackDistribution_CR_and_cleanup_resources (0.15s)
PASS
ok      github.com/meta-llama/llama-stack-k8s-operator/tests/e2e        48.415s
```