### PR TITLE
fix: simplify distribution validation rule

### DIFF
--- a/api/v1alpha1/llamastackdistribution_types.go
+++ b/api/v1alpha1/llamastackdistribution_types.go
@@ -26,8 +26,7 @@ import (
 )
 
 // DistributionType defines the distribution configuration for llama-stack.
-// +kubebuilder:validation:XValidation:rule="(self.name == '' && self.image != '') || (self.name != '' && self.image == '')",message="Only one of name or image can be specified"
-// +kubebuilder:validation:XValidation:rule="self.name != '' || self.image != ''",message="Either name or image must be specified"
+// +kubebuilder:validation:XValidation:rule="has(self.name) != has(self.image)",message="Only one of name or image can be specified"
 type DistributionType struct {
 	// Name is the distribution name that maps to supported distributions. Currently supported distributions are ollama and vllm.
 	// +optional

--- a/config/crd/bases/llama.x-k8s.io_llamastackdistributions.yaml
+++ b/config/crd/bases/llama.x-k8s.io_llamastackdistributions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: llamastackdistributions.llama.x-k8s.io
 spec:
   group: llama.x-k8s.io
@@ -229,9 +229,8 @@ spec:
                         type: object
                     type: object
                   distribution:
-                    description: |-
-                      DistributionType defines the distribution configuration for llama-stack.
-                      Using "" below for checking if the field is existing instead of ' ' as ' ' is reformatted to ” by gofmt.
+                    description: DistributionType defines the distribution configuration
+                      for llama-stack.
                     properties:
                       image:
                         description: Image is the direct container image reference
@@ -248,10 +247,7 @@ spec:
                     type: object
                     x-kubernetes-validations:
                     - message: Only one of name or image can be specified
-                      rule: (self.image == "" && self.image != "") || (self.name !=
-                        "" && self.image == "")
-                    - message: Either name or image must be specified
-                      rule: self.name != "" || self.image != ""
+                      rule: has(self.name) != has(self.image)
                   podOverrides:
                     description: PodOverrides allows advanced pod-level customization.
                     properties:


### PR DESCRIPTION
The previous validation rule for DistributionType was overly complex and required explicit empty values for unused fields. This change:

- Replaces the complex validation rule with a simpler `has()` check
- Ensures mutual exclusivity between name and image fields

The new validation rule `has(self.name) != has(self.image)` more clearly expresses the intent that only one of the fields should be present.