### PR TITLE
Update go version to 1.23

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -13,10 +13,10 @@ jobs:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-24.04
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go 1.23
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21'
+          go-version: '1.23'
           
       - name: Checkout code
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.23 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This repo hosts a kubernetes operator that is responsible for creating and manag
 
 #### Pre-requisites
 
-- Go version **go1.21**
-- operator-sdk version can be updated to **v1.31.1**
+- Go version **go1.23**
+- operator-sdk version can be updated to **v1.33+** (v4 layout)
 
 
 #### Build Image

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,16 @@
 module github.com/meta-llama/llama-stack-k8s-operator
 
-go 1.21.0
+go 1.23.0
 
 require (
 	github.com/go-logr/logr v1.4.1
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.2
 	k8s.io/apimachinery v0.29.2
 	k8s.io/client-go v0.29.2
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.17.2
 )
 
@@ -61,12 +63,10 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.0 // indirect
 	k8s.io/component-base v0.29.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect


### PR DESCRIPTION
This version updagrade is a follow-up to the operator-sdk update where latest versions require  Go 1.23