### PR TITLE
feat: Add version checking for controller-gen tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,9 +182,14 @@ $(KUSTOMIZE): $(LOCALBIN)
 	test -s $(LOCALBIN)/kustomize || { curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
 
 .PHONY: controller-gen
-controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
+controller-gen: ## Download controller-gen locally if necessary.
+	@if ! test -s $(LOCALBIN)/controller-gen || ! $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION); then \
+		echo "Installing controller-gen $(CONTROLLER_TOOLS_VERSION)"; \
+		GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION); \
+	fi
+
 $(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+	$(MAKE) controller-gen
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.


### PR DESCRIPTION
# Add Version Checking for controller-gen Tool

## Description

This PR enhances the Makefile by adding version checking for the controller-gen tool. Previously, the Makefile only checked if controller-gen was installed, but didn't verify if the installed version matched the version specified in `CONTROLLER_TOOLS_VERSION`. This could lead to subtle build issues if the wrong version was being used.

Motivation for this PR was that I had strange recommit issues because I had a local `codegen` binary in `bin` that was 0.17.2, but Makefile references 0.17.3. It didn't get reinstalled, but the GitHub action always installs it afresh (0.17.3) and therefor some differences in the generated manifest were detected.

## Changes

- Modified the controller-gen target in the Makefile to check both for existence AND version match
- If either the tool doesn't exist or the version doesn't match, it will reinstall the correct version

## Testing

Tested by:
- Manually verifying version checking works by intentionally changing the CONTROLLER_TOOLS_VERSION
- Confirming that the correct version gets installed when needed
- Confirming that no reinstallation happens when the correct version is already present
