### PR TITLE
Fix: Kustomize binary installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
 rm -f $(1) || true ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
+GOBIN=$(LOCALBIN) CGO_ENABLED=0 go install -v $${package} ;\
 mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)


### PR DESCRIPTION
Kustomize to use direct binary download. With latest changes that updates Makefile to use go-install doesn't seem to be working for kustomize. It downloads the binary successfully, but none of the kustomize commands are able to complete execution. Updated to support cross-platform compatibility

- Add platform-specific environment variables (GOOS, GOARCH) using go env
- Enable Go modules with GO111MODULE=on
- Build static binaries with CGO_ENABLED=0