### PR TITLE
ci: introduce mergify bot

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,51 @@
+pull_request_rules:
+- name: auto-merge
+  description: >
+    Automatic merge of PRs to main
+  conditions:
+    - "#approved-reviews-by>=1"
+    - "#review-requested=0"
+    - "#changes-requested-reviews-by=0"
+    - base=main
+    - label!=do-not-merge
+    - label!=needs-rebase
+    - check-success=pre-commit
+    - check-success=e2e-tests
+    # - check-success=DCO # TODO: uncomment when DCO check is added to the repo
+    # - check-success=build-latest-image # TODO: uncomment this when the credentials are added to the repo
+
+  actions:
+    merge:
+      method: squash
+      commit_message_template: |
+        {{ title }} (#{{ number }})
+
+        {{ body }}
+
+        {% for user in approved_reviews_by %}
+        Approved-by: {{ user }}
+        {% endfor %}
+    delete_head_branch:
+
+- name: ping author on conflicts and add 'needs-rebase' label
+  conditions:
+      - conflict
+      - -closed
+  actions:
+    label:
+      add:
+        - needs-rebase
+    comment:
+      message: >
+       This pull request has merge conflicts that must be resolved before it
+       can be merged. @{{author}} please rebase it.
+       https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
+
+- name: remove 'needs-rebase' label when conflict is resolved
+  conditions:
+      - -conflict
+      - -closed
+  actions:
+    label:
+      remove:
+        - needs-rebase


### PR DESCRIPTION
This enables the Mergify bot to:

* automatically merge PRs under certain conditions using the squash method (like we do today)
* ping autors and label PR when the code has conflicts, making it easy to identify by maintainers too