### PR TITLE
Update README.md to go version 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ spec:
 ### Prerequisites
 
 - Kubernetes cluster (v1.20 or later)
-- Go version **go1.23**
+- Go version **go1.24**
 - operator-sdk **v1.39.2** (v4 layout) or newer
 - kubectl configured to access your cluster
 - A running inference server:


### PR DESCRIPTION
Got the following error when I tried to run the `Make` file, had to update from 1.23 to 1.24 to get the Make script to work.

```
go: downloading sigs.k8s.io/controller-runtime v0.20.4
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20250513151321-9b5f6a71e9d6
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250513151321-9b5f6a71e9d6 requires go >= 1.24.0 (running go 1.23.8; GOTOOLCHAIN=local)
make: *** [Makefile:197: /home/jland/Documents/RedHat/llama-stack/llama-stack-k8s-operator/bin/setup-envtest] Error 1
```