### PR TITLE
fix: remove trailing line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,8 @@ api-docs: crd-ref-docs ## Creates API docs using https://github.com/elastic/crd-
 	@# Combined command to remove .io links, ensure a trailing newline, and collapse multiple blank lines.
 	@sed -i.bak -e '/\.io\/[^v][^1].*)/d' -e '/^$$/N;/^\n$$/D' $(API_DOCS_PATH)
 	@# BSD sed doesn't generate trailing newlines, so no need to remove them.
-	@if [ "$(shell uname)" != "Darwin" ]; then \
+	@# BSD sed does not have a '--version' flag, so we need to check for it.
+	@if sed --version >/dev/null 2>&1; then \
 		sed -i.bak -e '$${/^$$/d}' -e '$${N;/^\n$$/d}' $(API_DOCS_PATH); \
 	fi
 	rm -f $(API_DOCS_PATH).bak


### PR DESCRIPTION
The previous check wasn't entirely correct, since somone can run macOS but use gnu binaries.
Let's remove all ending trailing lines, if any, it doesn't hurt :)