### PR TITLE
Fix Kustomize Deprecation Warnings and Missing Files

### DIFF
--- a/config/manifests/bases/llama-stack-k8s-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/llama-stack-k8s-operator.clusterserviceversion.yaml
@@ -1,0 +1,47 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Basic Install
+  name: llama-stack-k8s-operator.v0.0.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - displayName: Llama Stack Distribution
+      kind: LlamaStackDistribution
+      name: llamastackdistributions.llamastack.io
+      version: v1alpha1
+  description: Llama Stack K8s Operator description. TODO.
+  displayName: Llama Stack K8s Operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      deployments: null
+    strategy: ""
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - llama-stack-k8s-operator
+  links:
+  - name: Llama Stack K8s Operator
+    url: https://llama-stack-k8s-operator.domain
+  maintainers:
+  - email: your@email.com
+    name: Maintainer Name
+  maturity: alpha
+  provider:
+    name: Provider Name
+    url: https://your.domain
+  version: 0.0.0

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -5,23 +5,5 @@ resources:
 - ../default
 - ../samples
 - ../scorecard
-
-# [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
-# Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
-# These patches remove the unnecessary "cert" volume and its manager container volumeMount.
-#patchesJson6902:
-#- target:
-#    group: apps
-#    version: v1
-#    kind: Deployment
-#    name: controller-manager
-#    namespace: system
-#  patch: |-
-#    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
-#    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
-#    - op: remove
-#      path: /spec/template/spec/containers/1/volumeMounts/0
-#    # Remove the "cert" volume, since OLM will create and mount a set of certs.
-#    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
-#    - op: remove
-#      path: /spec/template/spec/volumes/0
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,4 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
-- _v1alpha1_llamastack.yaml
+- _v1alpha1_llamastackdistribution.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
Deprecated key usage in our Kustomize files.
```shell
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
```

- [X] `kustomize edit fix --vars` to have Kustomize programmatically fix the issues with the deprecated keys, and the `vars` key (I believe that was the only experimental fix)
- [X] `operator-sdk generate kustomize manifests --interactive=false -q` to generate `config/manifests/bases` and its `llama-stack-k8s-operator.clusterserviceversion.yaml`