### PR TITLE
fix contributing docs on error messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ All error messages in the codebase must follow a consistent format to improve re
 
 ### Rules for Error Messages
 
-1. All error messages must start with "failed to"
+1. All **wrapped** error messages must start with "failed to"
 2. Error messages should be descriptive and actionable
 
 ## Questions?


### PR DESCRIPTION
Missed this [nit](https://github.com/llamastack/llama-stack-k8s-operator/pull/46#discussion_r2138536355) on the previous pull request to add the pre-commit hook to check golang wrapped errors.