### PR TITLE
feat(logging): disable stack traces in error logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	llamaxk8siov1alpha1 "github.com/llamastack/llama-stack-k8s-operator/api/v1alpha1"
 	"github.com/llamastack/llama-stack-k8s-operator/controllers"
 	"github.com/llamastack/llama-stack-k8s-operator/pkg/cluster"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -84,7 +85,8 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
-		Development: true,
+		Development:     true,
+		StacktraceLevel: zapcore.PanicLevel, // Set higher than ErrorLevel to avoid stack traces in logs
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Set zap logger's StacktraceLevel to PanicLevel to prevent stack traces from appearing in error logs. This makes the logs cleaner and more readable while still maintaining the error information needed for debugging.

Previously the logs where full of:

```
2025-06-16T08:00:06Z    ERROR   setup.controller        failed to check health endpoint {"llamastack": {"name":"llamastackdistribution-sample","namespace":"llama-stack-test"}, "llamastack": {"name":"llamastackdistribution-sample","namespace":"llama-stack-test"}, "llamastack": {"name":"llamastackdistribution-sample","namespace":"llama-stack-test"}, "llamastack": {"name":"llamastackdistribution-sample","namespace":"llama-stack-test"}, "llamastack": {"name":"llamastackdistribution-sample","namespace":"llama-stack-test"}, "error": "failed to make health check request: Get \"http://llamastackdistribution-sample-service.llama-stack-test.svc.cluster.local:8321/v1/health\": dial tcp 10.96.229.137:8321: connect: connection refused"}
github.com/llamastack/llama-stack-k8s-operator/controllers.(*LlamaStackDistributionReconciler).updateStatus
        /workspace/controllers/llamastackdistribution_controller.go:446
github.com/llamastack/llama-stack-k8s-operator/controllers.(*LlamaStackDistributionReconciler).reconcileResources
        /workspace/controllers/llamastackdistribution_controller.go:143
github.com/llamastack/llama-stack-k8s-operator/controllers.(*LlamaStackDistributionReconciler).Reconcile
        /workspace/controllers/llamastackdistribution_controller.go:90
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:119
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:316
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:227
```