### PR TITLE
feat(controller): add CR spec diff output on updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.23.0
 
 require (
 	github.com/go-logr/logr v1.4.1
+	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/stretchr/testify v1.10.0
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.2
 	k8s.io/apiextensions-apiserver v0.29.0
@@ -25,7 +27,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
@@ -38,7 +39,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
@@ -74,7 +74,6 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/component-base v0.29.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect


### PR DESCRIPTION
Add diff output when LlamaStackDistribution CR spec changes using go-cmp. The diff is printed separately from structured logging for better readability. This helps operators track and understand changes to CR configurations.

Example:

```
2025-06-16T08:45:56Z    INFO    LlamaStackDistribution CR spec changed  {"namespace": "llama-stack-test", "name": "llamastackdistribution-sample"}
  v1alpha1.LlamaStackDistributionSpec{
        Replicas: 2,
        Server: v1alpha1.ServerSpec{
                Distribution: {Name: "ollama"},
                ContainerSpec: v1alpha1.ContainerSpec{
                        Name:      "llama-stack",
                        Port:      0,
                        Resources: {},
                        Env: []v1.EnvVar{
                                {
                                        Name:      "GOO",
-                                       Value:     "FOOOs",
+                                       Value:     "FOOO",
                                        ValueFrom: nil,
                                },
                                {Name: "INFERENCE_MODEL", Value: "llama3.2:1b"},
                                {Name: "OLLAMA_URL", Value: "http://ollama-server-service.ollama-dist.svc.cluster.local:11434"},
                        },
                },
                PodOverrides: nil,
                Storage:      &{Size: &{i: {...}, s: "20Gi", Format: "BinarySI"}, MountPath: "/home/lls/.lls"},
        },
  }
```