### PR TITLE
fix: point HuggingFace home directory to PVC mount

### DIFF
--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -30,7 +30,6 @@ func buildContainerSpec(instance *llamav1alpha1.LlamaStackDistribution, image st
 		Name:            llamav1alpha1.DefaultContainerName,
 		Image:           image,
 		Resources:       instance.Spec.Server.ContainerSpec.Resources,
-		Env:             instance.Spec.Server.ContainerSpec.Env,
 		ImagePullPolicy: corev1.PullAlways,
 	}
 
@@ -44,11 +43,25 @@ func buildContainerSpec(instance *llamav1alpha1.LlamaStackDistribution, image st
 	}
 	container.Ports = []corev1.ContainerPort{{ContainerPort: port}}
 
-	// Determine mount path
 	mountPath := llamav1alpha1.DefaultMountPath
-	if instance.Spec.Server.Storage != nil && instance.Spec.Server.Storage.MountPath != "" {
-		mountPath = instance.Spec.Server.Storage.MountPath
+	if instance.Spec.Server.Storage != nil {
+		// Determine mount path
+		if instance.Spec.Server.Storage.MountPath != "" {
+			mountPath = instance.Spec.Server.Storage.MountPath
+		}
 	}
+
+	// Add HF_HOME variable to our mount path so that downloaded models and datasets are stored
+	// on the same volume as the storage. This is not critical but useful if the server is
+	// restarted so the models and datasets are not lost and need to be downloaded again.
+	// For more information, see https://huggingface.co/docs/datasets/en/cache
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name:  "HF_HOME",
+		Value: mountPath,
+	})
+
+	// Finally, add the user provided env vars
+	container.Env = append(container.Env, instance.Spec.Server.ContainerSpec.Env...)
 
 	// Add volume mount for storage
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{

--- a/controllers/resource_helper_test.go
+++ b/controllers/resource_helper_test.go
@@ -54,6 +54,9 @@ func TestBuildContainerSpec(t *testing.T) {
 					Name:      "lls-storage",
 					MountPath: llamav1alpha1.DefaultMountPath,
 				}},
+				Env: []corev1.EnvVar{
+					{Name: "HF_HOME", Value: "/.llama"},
+				},
 			},
 		},
 		{
@@ -92,6 +95,7 @@ func TestBuildContainerSpec(t *testing.T) {
 					},
 				},
 				Env: []corev1.EnvVar{
+					{Name: "HF_HOME", Value: "/custom/path"},
 					{Name: "TEST_ENV", Value: "test-value"},
 				},
 				VolumeMounts: []corev1.VolumeMount{{
@@ -124,6 +128,9 @@ func TestBuildContainerSpec(t *testing.T) {
 					Name:      "lls-storage",
 					MountPath: llamav1alpha1.DefaultMountPath,
 				}},
+				Env: []corev1.EnvVar{
+					{Name: "HF_HOME", Value: "/.llama"},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Depending on the distribution configuration, some models might get downloaded. This is true when the sentence-transformers provider is used. The library will download embedding models in the local filesystem using the HuggingFace library. We want to use the PVC mount to store the Datasets and the Hub artifact. For this, we need to set the `HF_HOME` env variable to our PVC mount.

This is important so that we:

* Avoid re-downloading models if the Pod moves
* Do not fill the host filesystem
* Take advantage of potentially faster storage than the host

In Kubernetes, when we append environment variables, if there's a duplicate name, the last one in the list takes precedence. So, a user-provided environment variable will always be honored.