### PR TITLE
Release v0.2.0 of Operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
+VERSION ?= 0.2.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -53,7 +53,7 @@ OPERATOR_SDK_VERSION ?= v1.39.2
 ENVTEST_K8S_VERSION = 1.31.0
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/llamastack/llama-stack-k8s-operator:latest
+IMG ?= quay.io/llamastack/llama-stack-k8s-operator:v$(VERSION)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/manager/distribution-configmap.yaml
+++ b/config/manager/distribution-configmap.yaml
@@ -8,18 +8,10 @@ metadata:
 # The distribution images are immutable and should not be updated
 immutable: true
 data:
-  ollama: docker.io/llamastack/distribution-ollama:latest
-  hf-endpoint: docker.io/llamastack/distribution-hf-endpoint:latest
-  hf-serverless: docker.io/llamastack/distribution-hf-serverless:latest
-  bedrock: docker.io/llamastack/distribution-bedrock:latest
-  cerebras: docker.io/llamastack/distribution-cerebras:latest
-  nvidia: docker.io/llamastack/distribution-nvidia:latest
-  open-benchmark: docker.io/llamastack/distribution-open-benchmark:latest
-  passthrough: docker.io/llamastack/distribution-passthrough:latest
-  remote-vllm: docker.io/llamastack/distribution-remote-vllm:latest
-  sambanova: docker.io/llamastack/distribution-sambanova:latest
-  tgi: docker.io/llamastack/distribution-tgi:latest
-  together: docker.io/llamastack/distribution-together:latest
-  vllm-gpu: docker.io/llamastack/distribution-vllm-gpu:latest
-  watsonx: docker.io/llamastack/distribution-watsonx:latest
-  fireworks: docker.io/llamastack/distribution-fireworks:latest
+  starter: docker.io/llamastack/distribution-starter:0.2.9
+  ollama: docker.io/llamastack/distribution-ollama:0.2.9
+  bedrock: docker.io/llamastack/distribution-bedrock:0.2.9
+  remote-vllm: docker.io/llamastack/distribution-remote-vllm:0.2.9
+  tgi: docker.io/llamastack/distribution-tgi:0.2.9
+  together: docker.io/llamastack/distribution-together:0.2.9
+  vllm-gpu: docker.io/llamastack/distribution-vllm-gpu:0.2.9

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ configMapGenerator:
 images:
 - name: controller
   newName: quay.io/llamastack/llama-stack-k8s-operator
-  newTag: latest
+  newTag: v0.2.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,9 +40,9 @@ spec:
         - --leader-elect
         env:
         - name: OPERATOR_VERSION
-          value: "latest"
+          value: "0.2.0"
         - name: LLAMA_STACK_VERSION
-          value: "latest"
+          value: "0.2.9"
         image: controller:latest
         name: manager
         securityContext:

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -2370,21 +2370,13 @@ subjects:
 ---
 apiVersion: v1
 data:
-  bedrock: docker.io/llamastack/distribution-bedrock:latest
-  cerebras: docker.io/llamastack/distribution-cerebras:latest
-  fireworks: docker.io/llamastack/distribution-fireworks:latest
-  hf-endpoint: docker.io/llamastack/distribution-hf-endpoint:latest
-  hf-serverless: docker.io/llamastack/distribution-hf-serverless:latest
-  nvidia: docker.io/llamastack/distribution-nvidia:latest
-  ollama: docker.io/llamastack/distribution-ollama:latest
-  open-benchmark: docker.io/llamastack/distribution-open-benchmark:latest
-  passthrough: docker.io/llamastack/distribution-passthrough:latest
-  remote-vllm: docker.io/llamastack/distribution-remote-vllm:latest
-  sambanova: docker.io/llamastack/distribution-sambanova:latest
-  tgi: docker.io/llamastack/distribution-tgi:latest
-  together: docker.io/llamastack/distribution-together:latest
-  vllm-gpu: docker.io/llamastack/distribution-vllm-gpu:latest
-  watsonx: docker.io/llamastack/distribution-watsonx:latest
+  bedrock: docker.io/llamastack/distribution-bedrock:0.2.9
+  ollama: docker.io/llamastack/distribution-ollama:0.2.9
+  remote-vllm: docker.io/llamastack/distribution-remote-vllm:0.2.9
+  starter: docker.io/llamastack/distribution-starter:0.2.9
+  tgi: docker.io/llamastack/distribution-tgi:0.2.9
+  together: docker.io/llamastack/distribution-together:0.2.9
+  vllm-gpu: docker.io/llamastack/distribution-vllm-gpu:0.2.9
 immutable: true
 kind: ConfigMap
 metadata:
@@ -2471,10 +2463,10 @@ spec:
         - /manager
         env:
         - name: OPERATOR_VERSION
-          value: latest
+          value: 0.2.0
         - name: LLAMA_STACK_VERSION
-          value: latest
-        image: quay.io/llamastack/llama-stack-k8s-operator:latest
+          value: 0.2.9
+        image: quay.io/llamastack/llama-stack-k8s-operator:v0.2.0
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Tagging to `0.2.9` version of llama-stack, since `0.2.10` tag is not available `llamastack/distribution-remote-vllm`


Closes #70 