### PR TITLE
feat(name_prefix): add kustomize plugin to prefix resource names

### DIFF
--- a/pkg/deploy/plugins/name_prefix.go
+++ b/pkg/deploy/plugins/name_prefix.go
@@ -1,0 +1,80 @@
+package plugins
+
+import (
+	"fmt"
+	"slices"
+
+	"sigs.k8s.io/kustomize/api/resmap"
+)
+
+// NamePrefixConfig holds configuration for the name prefix plugin.
+type NamePrefixConfig struct {
+	// Prefix to add to resource names
+	Prefix string
+	// ResourceKinds specifies which resource kinds to apply the prefix to.
+	// If empty, applies to all resources. Allows for targeted prefixing.
+	ResourceKinds []string
+	// ExcludeKinds specifies which resource kinds to exclude from prefixing.
+	// Provides a way to opt-out specific kinds.
+	ExcludeKinds []string
+}
+
+// CreateNamePrefixPlugin creates a transformer plugin that adds a prefix to resource names.
+// Acts as a constructor, ensuring the plugin is properly initialized with its configuration.
+func CreateNamePrefixPlugin(config NamePrefixConfig) *namePrefixTransformer {
+	return &namePrefixTransformer{config: config}
+}
+
+type namePrefixTransformer struct {
+	config NamePrefixConfig
+}
+
+// Transform implements the TransformerPlugin interface.
+// Iterates through resources and applies the configured name prefix.
+func (t *namePrefixTransformer) Transform(m resmap.ResMap) error {
+	for _, res := range m.Resources() {
+		// Skip if the resource already has the prefix to prevent duplicates.
+		if hasPrefix(res.GetName(), t.config.Prefix+"-") {
+			continue
+		}
+
+		// Check if we should apply prefix to this resource kind based on include/exclude rules.
+		// Ensures only targeted resource kinds are modified.
+		if !shouldApplyToKind(res.GetKind(), t.config.ResourceKinds, t.config.ExcludeKinds) {
+			continue
+		}
+
+		// Performs the actual name prefixing for the resource.
+		if err := res.SetName(t.config.Prefix + "-" + res.GetName()); err != nil {
+			return fmt.Errorf("failed to set resource name: %w", err)
+		}
+	}
+	return nil
+}
+
+// Config implements the TransformerPlugin interface.
+// This method is empty because the plugin's configuration is provided directly via `CreateNamePrefixPlugin`.
+func (t *namePrefixTransformer) Config(h *resmap.PluginHelpers, _ []byte) error {
+	return nil
+}
+
+// shouldApplyToKind uses explicit include/exclude logic for flexibility in applying transformations.
+func shouldApplyToKind(kind string, includeKinds, excludeKinds []string) bool {
+	// Exclusions take precedence.
+	if len(excludeKinds) > 0 {
+		if slices.Contains(excludeKinds, kind) {
+			return false
+		}
+	}
+	// If include list is empty, apply to all kinds (unless excluded).
+	if len(includeKinds) == 0 {
+		return true
+	}
+	return slices.Contains(includeKinds, kind)
+}
+
+// hasPrefix checks if a string has a given prefix.
+// Utility function to avoid redundant prefixing.
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}

--- a/pkg/deploy/plugins/name_prefix.go
+++ b/pkg/deploy/plugins/name_prefix.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"sigs.k8s.io/kustomize/api/resmap"
 )
@@ -34,7 +35,7 @@ type namePrefixTransformer struct {
 func (t *namePrefixTransformer) Transform(m resmap.ResMap) error {
 	for _, res := range m.Resources() {
 		// Skip if the resource already has the prefix to prevent duplicates.
-		if hasPrefix(res.GetName(), t.config.Prefix+"-") {
+		if strings.HasPrefix(res.GetName(), t.config.Prefix+"-") {
 			continue
 		}
 
@@ -71,10 +72,4 @@ func shouldApplyToKind(kind string, includeKinds, excludeKinds []string) bool {
 		return true
 	}
 	return slices.Contains(includeKinds, kind)
-}
-
-// hasPrefix checks if a string has a given prefix.
-// Utility function to avoid redundant prefixing.
-func hasPrefix(s, prefix string) bool {
-	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }

--- a/pkg/deploy/plugins/name_prefix_test.go
+++ b/pkg/deploy/plugins/name_prefix_test.go
@@ -31,8 +31,8 @@ func TestNamePrefixTransformer(t *testing.T) {
 		{
 			name: "apply prefix only to included kinds",
 			transformer: CreateNamePrefixPlugin(NamePrefixConfig{
-				Prefix:        "my-prefix",
-				ResourceKinds: []string{"Deployment"},
+				Prefix:       "my-prefix",
+				IncludeKinds: []string{"Deployment"},
 			}),
 			initialResources: []*resource.Resource{
 				newTestResource(t, "apps/v1", "Deployment", "backend", "", nil),

--- a/pkg/deploy/plugins/name_prefix_test.go
+++ b/pkg/deploy/plugins/name_prefix_test.go
@@ -1,0 +1,89 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
+)
+
+func TestNamePrefixTransformer(t *testing.T) {
+	testCases := []struct {
+		name               string
+		transformer        *namePrefixTransformer
+		initialResources   []*resource.Resource
+		expectedFinalNames []string
+	}{
+		{
+			name: "apply prefix to all resources when no filters are set",
+			transformer: CreateNamePrefixPlugin(NamePrefixConfig{
+				Prefix: "my-prefix",
+			}),
+			initialResources: []*resource.Resource{
+				newTestResource(t, "apps/v1", "Deployment", "backend", "", nil),
+				newTestResource(t, "v1", "Service", "frontend", "", nil),
+			},
+			expectedFinalNames: []string{"my-prefix-backend", "my-prefix-frontend"},
+		},
+		{
+			name: "apply prefix only to included kinds",
+			transformer: CreateNamePrefixPlugin(NamePrefixConfig{
+				Prefix:        "my-prefix",
+				ResourceKinds: []string{"Deployment"},
+			}),
+			initialResources: []*resource.Resource{
+				newTestResource(t, "apps/v1", "Deployment", "backend", "", nil),
+				newTestResource(t, "v1", "Service", "frontend", "", nil),
+			},
+			expectedFinalNames: []string{"my-prefix-backend", "frontend"},
+		},
+		{
+			name: "do not apply prefix to excluded kinds",
+			transformer: CreateNamePrefixPlugin(NamePrefixConfig{
+				Prefix:       "my-prefix",
+				ExcludeKinds: []string{"Service"},
+			}),
+			initialResources: []*resource.Resource{
+				newTestResource(t, "apps/v1", "Deployment", "backend", "", nil),
+				newTestResource(t, "v1", "Service", "frontend", "", nil),
+			},
+			expectedFinalNames: []string{"my-prefix-backend", "frontend"},
+		},
+		{
+			name: "do not apply prefix if already present",
+			transformer: CreateNamePrefixPlugin(NamePrefixConfig{
+				Prefix: "my-prefix",
+			}),
+			initialResources: []*resource.Resource{
+				newTestResource(t, "apps/v1", "Deployment", "my-prefix-backend", "", nil),
+				newTestResource(t, "v1", "Service", "frontend", "", nil),
+			},
+			expectedFinalNames: []string{"my-prefix-backend", "my-prefix-frontend"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// setup
+			resMap := resmap.New()
+			for _, res := range tc.initialResources {
+				err := resMap.Append(res)
+				require.NoError(t, err)
+			}
+
+			// action
+			err := tc.transformer.Transform(resMap)
+			require.NoError(t, err)
+
+			// assertion
+			require.Equal(t, len(tc.initialResources), resMap.Size())
+
+			actualFinalNames := []string{}
+			for _, r := range resMap.Resources() {
+				actualFinalNames = append(actualFinalNames, r.GetName())
+			}
+			require.ElementsMatch(t, tc.expectedFinalNames, actualFinalNames)
+		})
+	}
+}

--- a/pkg/deploy/plugins/name_prefix_test.go
+++ b/pkg/deploy/plugins/name_prefix_test.go
@@ -92,7 +92,6 @@ func TestNamePrefixTransformer(t *testing.T) {
 			if tc.expectError {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.expectedErrStr)
-
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, len(tc.initialResources), resMap.Size())


### PR DESCRIPTION
- [X] Adds a Kustomize plugin that enables users to prefix a given Kind of Resources with a given string. You can also exclude a set of Kinds to not be prefixed.