### PR TITLE
[ACTION] Applied SHA-pinned actions #53

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Go 1.23
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
         with:
-          go-version: '1.23'
+          go-version: "1.23"
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Login to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           registry: quay.io
           username: ${{ secrets.APP_QUAY_USERNAME }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -3,22 +3,22 @@ name: Tests Code Coverage
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
         with:
-          go-version: '1.21'
+          go-version: "1.21"
 
       - name: Set up limgo
-        uses: GoTestTools/limgo-action@v1.0.2
+        uses: GoTestTools/limgo-action@d4a725a46ab3bdbbf23186bbbe54b4ff4a35d5a7 #v1.0.2
         with:
           version: "v1.0.0"
           install-only: true
@@ -33,7 +33,7 @@ jobs:
           cat /tmp/covcheck.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload test coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ always() }}
         with:
           name: test-coverage-results

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Go env
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g., 1.2.1)'
+        description: "Version to release (e.g., 1.2.1)"
         required: true
         type: string
       release_branch:
-        description: 'Release branch name (e.g., release-1.2)'
+        description: "Release branch name (e.g., release-1.2)"
         required: true
         type: string
 
@@ -21,17 +21,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Go 1.23
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
         with:
-          go-version: '1.23'
+          go-version: "1.23"
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.inputs.release_branch }}
 
       - name: Login to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           registry: quay.io
           username: ${{ secrets.APP_QUAY_USERNAME }}

--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -3,22 +3,22 @@ name: Run E2E Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
         with:
-          go-version: '1.21'
+          go-version: "1.21"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Create kind config
         run: |
@@ -49,7 +49,7 @@ jobs:
 
       - name: Create k8s Kind Cluster
         id: kind
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 #v1.12.0
         with:
           registry: true
           registry_name: kind-registry

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,32 +1,32 @@
-exclude: 'build/'
+exclude: "build/"
 
 default_language_version:
-    python: python3
+  python: python3
 
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0  # Latest stable version
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0 # Latest stable version
     hooks:
-    -   id: check-merge-conflict
-        args: ['--assume-in-merge']
-    -   id: trailing-whitespace
-    -   id: check-added-large-files
-        args: ['--maxkb=1000']
-    -   id: end-of-file-fixer
+      - id: check-merge-conflict
+        args: ["--assume-in-merge"]
+      - id: trailing-whitespace
+      - id: check-added-large-files
+        args: ["--maxkb=1000"]
+      - id: end-of-file-fixer
         exclude: '^(.*\.svg)$'
-    -   id: no-commit-to-branch
-    -   id: check-yaml
+      - id: no-commit-to-branch
+      - id: check-yaml
         args: ["--unsafe"]
-    -   id: detect-private-key
-    -   id: mixed-line-ending
+      - id: detect-private-key
+      - id: mixed-line-ending
         args: [--fix=lf] # Forces to replace line ending by LF (line feed)
-    -   id: check-executables-have-shebangs
-    -   id: check-json
-    -   id: check-shebang-scripts-are-executable
-    -   id: check-symlinks
-    -   id: check-toml
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: check-toml
 
--   repo: local
+  - repo: local
     hooks:
       - id: linters
         name: Linters
@@ -57,3 +57,11 @@ repos:
         entry: ./hack/check_go_errors.py
         language: python
         types: [go]
+      - id: check-workflows-use-hashes
+        name: Check GitHub Actions use SHA-pinned actions
+        entry: ./hack/check-workflows-uses-hashesh.sh
+        language: system
+        pass_filenames: false
+        require_serial: true
+        always_run: true
+        files: ^\.github/workflows/.*\.ya?ml$

--- a/hack/check-workflows-uses-hashesh.sh
+++ b/hack/check-workflows-uses-hashesh.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+#
+# Fails if any GitHub Actions workflow uses an external action without a full SHA pin.
+
+set -euo pipefail
+
+failed=0
+
+# Find all workflow YAML files
+for file in $(find .github/workflows/ -type f \( -name "*.yml" -o -name "*.yaml" \)); do
+  IFS=$'\n'
+  # Grep for `uses:` lines that look like actions
+  for line in $(grep -E '^.*uses:[^@]+@[^ ]+' "$file"); do
+    # Extract the ref part after the last @
+    ref=$(echo "$line" | sed -E 's/.*@([A-Za-z0-9._-]+).*/\1/')
+    # Check if ref is a 40-character hex string (full SHA).
+    #
+    # Note: strictly speaking, this could also be a tag or branch name, but
+    # we'd have to pull this info from the remote. Meh.
+    if ! [[ $ref =~ ^[0-9a-fA-F]{40}$ ]]; then
+      echo "ERROR: $file uses non-SHA action ref: $line"
+      failed=1
+    fi
+  done
+done
+
+exit $failed

--- a/hack/check-workflows-uses-hashesh.sh
+++ b/hack/check-workflows-uses-hashesh.sh
@@ -19,7 +19,7 @@ for file in $(find .github/workflows/ -type f \( -name "*.yml" -o -name "*.yaml"
     # Extract the ref part after the last @
     ref=$(echo "$line" | sed -E 's/.*@([A-Za-z0-9._-]+).*/\1/')
     # Check if ref is a 40-character hex string (full SHA).
-    #
+
     # Note: strictly speaking, this could also be a tag or branch name, but
     # we'd have to pull this info from the remote. Meh.
     if ! [[ $ref =~ ^[0-9a-fA-F]{40}$ ]]; then

--- a/pkg/deploy/plugins/name_prefix.go
+++ b/pkg/deploy/plugins/name_prefix.go
@@ -1,0 +1,90 @@
+package plugins
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/kustomize/api/resmap"
+)
+
+// NamePrefixConfig holds configuration for the name prefix plugin.
+type NamePrefixConfig struct {
+	// Prefix to add to resource names.
+	Prefix string
+	// IncludeKinds specifies which resource kinds to apply the prefix to.
+	// If empty, the prefix is applied to all resource kinds not specified in ExcludeKinds.
+	IncludeKinds []string
+	// ExcludeKinds specifies which resource kinds to exclude from prefixing.
+	// This list takes precedence over IncludeKinds; if a kind is in both lists,
+	// it will be excluded.
+	ExcludeKinds []string
+}
+
+// CreateNamePrefixPlugin creates a transformer plugin that adds a prefix to resource names.
+// Acts as a constructor, ensuring the plugin is properly initialized with its configuration.
+func CreateNamePrefixPlugin(config NamePrefixConfig) *namePrefixTransformer {
+	return &namePrefixTransformer{config: config}
+}
+
+type namePrefixTransformer struct {
+	config NamePrefixConfig
+}
+
+// Transform implements the TransformerPlugin interface.
+// Iterates through resources and applies the configured name prefix.
+func (t *namePrefixTransformer) Transform(m resmap.ResMap) error {
+	for _, res := range m.Resources() {
+		// Skip if the resource already has the prefix to prevent duplicates.
+		if strings.HasPrefix(res.GetName(), t.config.Prefix+"-") {
+			continue
+		}
+
+		// Check if we should apply prefix to this resource kind based on include/exclude rules.
+		// Ensures only targeted resource kinds are modified.
+		if !shouldApplyToKind(res.GetKind(), t.config.IncludeKinds, t.config.ExcludeKinds) {
+			continue
+		}
+
+		prefixedName := makePrefixedName(t.config.Prefix, res.GetName())
+		// Use the strictest naming rule (for Namespaces) to ensure the new name string
+		// is valid for any given Resource.
+		if errs := k8svalidation.IsDNS1123Label(prefixedName); len(errs) > 0 {
+			return fmt.Errorf("failed to make valid prefixed name for %q: %s",
+				prefixedName, strings.Join(errs, ", "))
+		}
+
+		// Performs the actual name prefixing for the resource.
+		if err := res.SetName(prefixedName); err != nil {
+			return fmt.Errorf("failed to set resource name: %w", err)
+		}
+	}
+	return nil
+}
+
+// Config implements the TransformerPlugin interface.
+// This method is empty because the plugin's configuration is provided directly via `CreateNamePrefixPlugin`.
+func (t *namePrefixTransformer) Config(h *resmap.PluginHelpers, _ []byte) error {
+	return nil
+}
+
+// shouldApplyToKind uses explicit include/exclude logic for flexibility in applying transformations.
+func shouldApplyToKind(kind string, includeKinds, excludeKinds []string) bool {
+	// Exclusions take precedence.
+	if len(excludeKinds) > 0 {
+		if slices.Contains(excludeKinds, kind) {
+			return false
+		}
+	}
+	// If include list is empty, apply to all kinds (that weren't excluded).
+	if len(includeKinds) == 0 {
+		return true
+	}
+	// Otherwise, only apply if the kind is explicitly included.
+	return slices.Contains(includeKinds, kind)
+}
+
+func makePrefixedName(prefix, name string) string {
+	return prefix + "-" + name
+}

--- a/pkg/deploy/plugins/name_prefix_test.go
+++ b/pkg/deploy/plugins/name_prefix_test.go
@@ -1,0 +1,107 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
+)
+
+func TestNamePrefixTransformer(t *testing.T) {
+	testCases := []struct {
+		name               string
+		transformer        *namePrefixTransformer
+		initialResources   []*resource.Resource
+		expectedFinalNames []string
+		expectError        bool
+		expectedErrStr     string
+	}{
+		{
+			name: "apply prefix to all resources when no filters are set",
+			transformer: CreateNamePrefixPlugin(NamePrefixConfig{
+				Prefix: "my-prefix",
+			}),
+			initialResources: []*resource.Resource{
+				newTestResource(t, "apps/v1", "Deployment", "backend", "", nil),
+				newTestResource(t, "v1", "Service", "frontend", "", nil),
+			},
+			expectedFinalNames: []string{"my-prefix-backend", "my-prefix-frontend"},
+		},
+		{
+			name: "apply prefix only to included kinds",
+			transformer: CreateNamePrefixPlugin(NamePrefixConfig{
+				Prefix:       "my-prefix",
+				IncludeKinds: []string{"Deployment"},
+			}),
+			initialResources: []*resource.Resource{
+				newTestResource(t, "apps/v1", "Deployment", "backend", "", nil),
+				newTestResource(t, "v1", "Service", "frontend", "", nil),
+			},
+			expectedFinalNames: []string{"my-prefix-backend", "frontend"},
+		},
+		{
+			name: "do not apply prefix to excluded kinds",
+			transformer: CreateNamePrefixPlugin(NamePrefixConfig{
+				Prefix:       "my-prefix",
+				ExcludeKinds: []string{"Service"},
+			}),
+			initialResources: []*resource.Resource{
+				newTestResource(t, "apps/v1", "Deployment", "backend", "", nil),
+				newTestResource(t, "v1", "Service", "frontend", "", nil),
+			},
+			expectedFinalNames: []string{"my-prefix-backend", "frontend"},
+		},
+		{
+			name: "do not apply prefix if already present",
+			transformer: CreateNamePrefixPlugin(NamePrefixConfig{
+				Prefix: "my-prefix",
+			}),
+			initialResources: []*resource.Resource{
+				newTestResource(t, "apps/v1", "Deployment", "my-prefix-backend", "", nil),
+				newTestResource(t, "v1", "Service", "frontend", "", nil),
+			},
+			expectedFinalNames: []string{"my-prefix-backend", "my-prefix-frontend"},
+		},
+		{
+			name: "error on invalid prefixed name",
+			transformer: CreateNamePrefixPlugin(NamePrefixConfig{
+				Prefix: "my.prefix",
+			}),
+			initialResources: []*resource.Resource{
+				newTestResource(t, "apps/v1", "Deployment", "backend", "", nil),
+			},
+			expectError:    true,
+			expectedErrStr: "failed to make valid prefixed name",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// setup
+			resMap := resmap.New()
+			for _, res := range tc.initialResources {
+				err := resMap.Append(res)
+				require.NoError(t, err)
+			}
+
+			// action
+			err := tc.transformer.Transform(resMap)
+
+			// assertion
+			if tc.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErrStr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, len(tc.initialResources), resMap.Size())
+
+				actualFinalNames := []string{}
+				for _, r := range resMap.Resources() {
+					actualFinalNames = append(actualFinalNames, r.GetName())
+				}
+				require.ElementsMatch(t, tc.expectedFinalNames, actualFinalNames)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Applied SHA as per the request.

- [x] Applied SHA1 for all uses statements
- [x] Added a pre-commit check

```
 grep -RE '^.*uses:[^@]+@[^ ]+' .github/workflows/
.github/workflows/release-image.yml:        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
.github/workflows/release-image.yml:        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
.github/workflows/release-image.yml:        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
.github/workflows/run-e2e-test.yml:        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
.github/workflows/run-e2e-test.yml:        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
.github/workflows/run-e2e-test.yml:        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
.github/workflows/run-e2e-test.yml:        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 #v1.12.0
.github/workflows/run-e2e-test.yml:        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
.github/workflows/pre-commit.yml:        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
.github/workflows/pre-commit.yml:        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
.github/workflows/pre-commit.yml:      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
.github/workflows/build-image.yml:        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
.github/workflows/build-image.yml:        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
.github/workflows/build-image.yml:        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
.github/workflows/code-coverage.yml:        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
.github/workflows/code-coverage.yml:        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
.github/workflows/code-coverage.yml:        uses: GoTestTools/limgo-action@d4a725a46ab3bdbbf23186bbbe54b4ff4a35d5a7 #v1.0.2
.github/workflows/code-coverage.yml:        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
```