### PR TITLE
feat: add support in Makefile for better local deveopment

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -29,4 +29,4 @@ jobs:
           password: ${{ secrets.APP_QUAY_TOKEN }}
 
       - name: Build and push latest image
-        run: make docker-build docker-push -e IMG=quay.io/llamastack/llama-stack-k8s-operator:latest
+        run: make image-build image-push -e IMG=quay.io/llamastack/llama-stack-k8s-operator:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY pkg/ pkg/
 USER root
 
 # GOARCH is intentionally left empty to automatically detect the host architecture
-# This ensures the binary matches the platform where docker-build is executed
+# This ensures the binary matches the platform where image-build is executed
 RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ kubectl apply -f config/samples/example-with-configmap.yaml
   ```
 
   The default image used is `quay.io/llamastack/llama-stack-k8s-operator:latest` when not supply argument for `make image`
+  To create a local file `local.mk` with env variables can overwrite the default values set in the `Makefile`.
 
 - Once the image is created, the operator can be deployed directly. For each deployment method a
   kubeconfig should be exported

--- a/docs/create-operator.md
+++ b/docs/create-operator.md
@@ -44,7 +44,7 @@ The operator's container image needs to be built and pushed to a container regis
 **Note:** Replace `<your-namespace>` with your actual registry and namespace.
 
 ```bash
-make docker-build IMG=$REGISTRY/$REGISTRY_NAMESPACE/llama-stack-operator:$TAG
+make image-build IMG=$REGISTRY/$REGISTRY_NAMESPACE/llama-stack-operator:$TAG
 podman push $REGISTRY/$REGISTRY_NAMESPACE/llama-stack-operator:$TAG
 ```
 


### PR DESCRIPTION
- use local.mk with pre-set env varibles: "make image IMG=XXX" and simplify to "make image"
- introduce new variable "IMG_TAG" to be keep old behavior
- rename target from "docker-build"/"docker-push" to "image-build"/"image-push" since we support podman by default
- create new target "clean"
- update documents and other place referred to updates


test:
1. made local.mk with 
```
VERSION=25.7.2
IMAGE_TAG_BASE=quay.io/wenzhou/llama-stack-k8s-operator
IMG_TAG=$(VERSION)
```
 then ran `make image build-installer`
generated `quay.io/wenzhou/llama-stack-k8s-operator:25.7.2`

2. removed local.mk to run `make image build-installer`
it calls `podman build -t quay.io/llamastack/llama-stack-k8s-operator:latest .`