### PR TITLE
chore: short name for operator CRD

### DIFF
--- a/api/v1alpha1/llamastackdistribution_types.go
+++ b/api/v1alpha1/llamastackdistribution_types.go
@@ -181,6 +181,7 @@ type LlamaStackDistributionStatus struct {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:shortName=llsd
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 //+kubebuilder:printcolumn:name="Operator Version",type="string",JSONPath=".status.version.operatorVersion"

--- a/config/crd/bases/llamastack.io_llamastackdistributions.yaml
+++ b/config/crd/bases/llamastack.io_llamastackdistributions.yaml
@@ -11,6 +11,8 @@ spec:
     kind: LlamaStackDistribution
     listKind: LlamaStackDistributionList
     plural: llamastackdistributions
+    shortNames:
+    - llsd
     singular: llamastackdistribution
   scope: Namespaced
   versions:

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -20,6 +20,8 @@ spec:
     kind: LlamaStackDistribution
     listKind: LlamaStackDistributionList
     plural: llamastackdistributions
+    shortNames:
+    - llsd
     singular: llamastackdistribution
   scope: Namespaced
   versions:


### PR DESCRIPTION
Since `llamastackdistribution` is quiet a long resource name, I am proposing to use a `shortName` for it.