### PR TITLE
refactor: consolidate security annotations

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,29 +9,25 @@ rules:
   resources:
   - configmaps
   verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - deployments
-  - persistentvolumes
-  - pods
-  - pods/exec
-  - pods/log
-  verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
   - persistentvolumeclaims
-  - services
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
-  - serviceaccounts
-  - services/finalizers
+  - services
   verbs:
   - create
   - delete
@@ -45,13 +41,13 @@ rules:
   resources:
   - deployments
   verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments/finalizers
-  verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - llamastack.io
   resources:
@@ -83,4 +79,10 @@ rules:
   resources:
   - networkpolicies
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/kubebuilder_rbac.go
+++ b/controllers/kubebuilder_rbac.go
@@ -1,26 +1,21 @@
 package controllers
 
+// LlamaStackDistribution CRD permissions
 //+kubebuilder:rbac:groups=llamastack.io,resources=llamastackdistributions,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=llamastack.io,resources=llamastackdistributions/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=llamastack.io,resources=llamastackdistributions/finalizers,verbs=update
 
-// +kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// Deployment permissions - controller creates and manages deployments
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 
-// +kubebuilder:rbac:groups="core",resources=pods/log,verbs=*
-// +kubebuilder:rbac:groups="core",resources=pods/exec,verbs=*
-// +kubebuilder:rbac:groups="core",resources=pods,verbs=*
+// Service permissions - controller creates and manages services
+//+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 
-// +kubebuilder:rbac:groups="core",resources=persistentvolumes,verbs=*
-// +kubebuilder:rbac:groups="core",resources=persistentvolumeclaims,verbs=*
+// PVC permissions - controller creates PVCs (immutable after creation, no update/patch needed)
+//+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create
 
-// +kubebuilder:rbac:groups="apps",resources=deployments/finalizers,verbs=*
-// +kubebuilder:rbac:groups="core",resources=deployments,verbs=*
-// +kubebuilder:rbac:groups="apps",resources=deployments,verbs=*
+// ConfigMap permissions - controller reads user configmaps and manages operator config configmaps
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch
 
-// +kubebuilder:rbac:groups="core",resources=services/finalizers,verbs=create;delete;list;update;watch;patch;get
-// +kubebuilder:rbac:groups="core",resources=services,verbs=get;create;watch;update;patch;list;delete
-// +kubebuilder:rbac:groups="core",resources=services,verbs=*
-
-// +kubebuilder:rbac:groups="core",resources=configmaps,verbs=*
-
-// +kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs=*
+// NetworkPolicy permissions - controller creates and manages network policies
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -53,15 +53,6 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
-//+kubebuilder:rbac:groups=llamastack.io,resources=llamastackdistributions,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=llamastack.io,resources=llamastackdistributions/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=llamastack.io,resources=llamastackdistributions/finalizers,verbs=update
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
-
 const (
 	operatorConfigData = "llama-stack-operator-config"
 	manifestsBasePath  = "manifests/base"

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -2244,29 +2244,25 @@ rules:
   resources:
   - configmaps
   verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - deployments
-  - persistentvolumes
-  - pods
-  - pods/exec
-  - pods/log
-  verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
   - persistentvolumeclaims
-  - services
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
-  - serviceaccounts
-  - services/finalizers
+  - services
   verbs:
   - create
   - delete
@@ -2280,13 +2276,13 @@ rules:
   resources:
   - deployments
   verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments/finalizers
-  verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - llamastack.io
   resources:
@@ -2318,7 +2314,13 @@ rules:
   resources:
   - networkpolicies
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Trimming down existing wildcard RBAC permissions via kubebuilder markers.

Tested on an OpenShift 4.18.17 | Kubernetes v1.31.9 cluster.

Closes #18 