### PR TITLE
feat(cli): enable selective test execution in make test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,46 @@ All error messages in the codebase must follow a consistent format to improve re
 1. All **wrapped** error messages must start with "failed to"
 2. Error messages should be descriptive and actionable
 
+## Testing
+
+### Running Tests
+
+The project uses `make test` to run the unit tests. By default, this runs all tests except end-to-end tests with code coverage.
+
+```bash
+# Run all tests (default behavior)
+make test
+
+# Run tests for a specific package
+make test TEST_PKGS=./pkg/deploy
+
+# Run a specific test function
+make test TEST_PKGS=./pkg/deploy TEST_FLAGS="-v -run TestRenderManifest"
+
+# Run tests with verbose output
+make test TEST_FLAGS="-v -coverprofile cover.out"
+
+# Run tests for multiple packages
+make test TEST_PKGS="./pkg/deploy ./controllers"
+```
+
+### Test Configuration Variables
+
+The `make test` target supports the following variables for customization:
+
+- `TEST_PKGS` - Space-separated list of packages to test (default: all packages except e2e)
+- `TEST_FLAGS` - Additional flags to pass to `go test` (default: `-coverprofile cover.out`)
+
+### Test-Driven Development (TDD)
+
+For rapid development cycles, you can use focused test runs:
+
+```bash
+# Example TDD workflow for working on the deploy package
+make test TEST_PKGS=./pkg/deploy TEST_FLAGS="-v -run TestRenderManifest"
+```
+
+
 ## Questions?
 
 If you have any questions about contributing, please open an issue in the repository.

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ SHELL = /usr/bin/env bash -o pipefail
 # See README.md, default go test timeout 10m
 E2E_TEST_FLAGS = -timeout 30m
 
+# Test configuration
+TEST_PKGS ?= $$(go list ./... | grep -v /e2e)
+TEST_FLAGS ?= -coverprofile cover.out
+
 # Include local.mk if it exists (for custom overrides)
 -include local.mk
 
@@ -136,8 +140,8 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+test: manifests generate fmt vet envtest ## Run tests. Use TEST_PKGS and TEST_FLAGS to customize.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(TEST_PKGS) $(TEST_FLAGS)
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests


### PR DESCRIPTION
The make test extension adds `TEST_PKGS` and `TEST_FLAGS` variables to the Makefile, allowing developers to run specific test packages or functions instead of the entire test suite. This maintains backward compatibility while enabling faster TDD workflows like `make test TEST_PKGS=./pkg/deploy TEST_FLAGS="-v -run TestRenderManifest"`.