### PR TITLE
Adding MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Meta Platforms, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Meta Platforms, Inc.
+Copyright (c) 2025 llamastack
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This is a re-make of #98 , that was prematurely approved (sorry, my bad).

People have still some concerns that we need to resolve before merging the license. 
It can be an easy discussion, but IANAL, so better play safe and listen to some more voices.

The questions actually are:

* What is the implication to have `Copyright (c) 2025 Meta Llama` wrt to future work and when moving potentially to a foundation later ? Wouldn't it be bettet to use a neutral term like `Copyright (c) 2025 The Llama Stack community` ?
* There are still repos in the GitHub `llamastack` org that uses an APL license, eg. [llama-stack-client-typescript/LICENSE](https://github.com/llamastack/llama-stack-client-typescript/blob/generated/LICENSE), but I have the feeling all repos in that org should leverage the same license. 
* Also, other projects that are using the MIT license, have a different copyright holder line, like `Copyright (c) Meta Platforms, Inc. and affiliates` in [llamastack/llama-stack-client-python](https://github.com/llamastack/llama-stack-client-python/blob/fe7130c105885a97cbc67410050a45f3de2f2db5/LICENSE)

My proposal would be to settle on a single license file with the same content and update all repositories atomically.

