### PR TITLE
feat(controller): migrate service reconciliation to kustomize manifest

### DIFF
--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -225,6 +225,11 @@ func (r *LlamaStackDistributionReconciler) reconcileResources(ctx context.Contex
 		}
 	}
 
+	// Reconcile manifest-based resources
+	if err := r.reconcileManifestResources(ctx, instance); err != nil {
+		return err
+	}
+
 	// Reconcile the NetworkPolicy
 	if err := r.reconcileNetworkPolicy(ctx, instance); err != nil {
 		return fmt.Errorf("failed to reconcile NetworkPolicy: %w", err)
@@ -238,13 +243,6 @@ func (r *LlamaStackDistributionReconciler) reconcileResources(ctx context.Contex
 	// Reconcile the Deployment
 	if err := r.reconcileDeployment(ctx, instance); err != nil {
 		return fmt.Errorf("failed to reconcile Deployment: %w", err)
-	}
-
-	// Reconcile the Service if ports are defined, else use default port
-	if instance.HasPorts() {
-		if err := r.reconcileService(ctx, instance); err != nil {
-			return fmt.Errorf("failed to reconcile service: %w", err)
-		}
 	}
 
 	return nil
@@ -654,36 +652,6 @@ func (r *LlamaStackDistributionReconciler) reconcileDeployment(ctx context.Conte
 	}
 
 	return deploy.ApplyDeployment(ctx, r.Client, r.Scheme, instance, deployment, logger)
-}
-
-// reconcileService manages the Service if ports are defined.
-func (r *LlamaStackDistributionReconciler) reconcileService(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) error {
-	logger := log.FromContext(ctx)
-	// Use the container's port (defaulted to 8321 if unset)
-	port := deploy.GetServicePort(instance)
-
-	service := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      deploy.GetServiceName(instance),
-			Namespace: instance.Namespace,
-		},
-		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{
-				llamav1alpha1.DefaultLabelKey: llamav1alpha1.DefaultLabelValue,
-				"app.kubernetes.io/instance":  instance.Name,
-			},
-			Ports: []corev1.ServicePort{{
-				Name: llamav1alpha1.DefaultServicePortName,
-				Port: port,
-				TargetPort: intstr.IntOrString{
-					IntVal: port,
-				},
-			}},
-			Type: corev1.ServiceTypeClusterIP,
-		},
-	}
-
-	return deploy.ApplyService(ctx, r.Client, r.Scheme, instance, service, logger)
 }
 
 // getServerURL returns the URL for the LlamaStack server.

--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -235,11 +235,6 @@ func (r *LlamaStackDistributionReconciler) reconcileResources(ctx context.Contex
 		return fmt.Errorf("failed to reconcile NetworkPolicy: %w", err)
 	}
 
-	// Reconcile manifest-based resources
-	if err := r.reconcileManifestResources(ctx, instance); err != nil {
-		return err
-	}
-
 	// Reconcile the Deployment
 	if err := r.reconcileDeployment(ctx, instance); err != nil {
 		return fmt.Errorf("failed to reconcile Deployment: %w", err)

--- a/controllers/manifests/base/kustomization.yaml
+++ b/controllers/manifests/base/kustomization.yaml
@@ -5,9 +5,10 @@ resources:
 - pvc.yaml
 - serviceaccount.yaml
 - scc-binding.yaml
+- service.yaml
 
 labels:
-- includeSelectors: true
+- includeSelectors: false
   pairs:
     app.kubernetes.io/managed-by: llama-stack-operator
     app.kubernetes.io/part-of: llama-stack

--- a/controllers/manifests/base/service.yaml
+++ b/controllers/manifests/base/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+spec:
+  type: ClusterIP
+  selector: {}
+  ports:
+  - name: http
+    protocol: TCP

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-logr/logr"
 	llamav1alpha1 "github.com/llamastack/llama-stack-k8s-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -39,31 +38,6 @@ func ApplyDeployment(ctx context.Context, cli client.Client, scheme *runtime.Sch
 		// Ensure the deployment has proper TypeMeta for server-side apply
 		deployment.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
 		return cli.Patch(ctx, deployment, client.Apply, client.ForceOwnership, client.FieldOwner("llama-stack-operator"))
-	}
-	return nil
-}
-
-// ApplyService creates or updates the Service.
-func ApplyService(ctx context.Context, cli client.Client, scheme *runtime.Scheme,
-	instance *llamav1alpha1.LlamaStackDistribution, service *corev1.Service, logger logr.Logger) error {
-	if err := ctrl.SetControllerReference(instance, service, scheme); err != nil {
-		return fmt.Errorf("failed to set controller reference: %w", err)
-	}
-
-	found := &corev1.Service{}
-	err := cli.Get(ctx, client.ObjectKeyFromObject(service), found)
-	if err != nil && errors.IsNotFound(err) {
-		logger.Info("Creating Service", "service", service.Name)
-		return cli.Create(ctx, service)
-	} else if err != nil {
-		return fmt.Errorf("failed to fetch Service: %w", err)
-	}
-
-	if !reflect.DeepEqual(found.Spec.Selector, service.Spec.Selector) || !reflect.DeepEqual(found.Spec.Ports, service.Spec.Ports) {
-		found.Spec.Selector = service.Spec.Selector
-		found.Spec.Ports = service.Spec.Ports
-		logger.Info("Updating Service", "service", service.Name)
-		return cli.Update(ctx, found)
 	}
 	return nil
 }


### PR DESCRIPTION
Migrate service creation from programmatic to manifest-based Kustomizer pipeline, with added service comparison utilities to detect unexpected changes and enforce field mutability boundaries between operator-managed and cluster-managed state.