### PR TITLE
empty plugin

### DIFF
--- a/pkg/deploy/plugins/empty_plugin.go
+++ b/pkg/deploy/plugins/empty_plugin.go
@@ -1,0 +1,1 @@
+package plugins


### PR DESCRIPTION
e2e tests keep failing on my `migrate-svc-reconciliation` branch from running out of disk space, so I'm verifying if that's happening on `main`