### PR TITLE
Use LLS version endpoint in Status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,6 @@ release: yq kustomize yamlfmt ## Prepare release files with VERSION and LLAMASTA
 	# Update environment variables in manager.yaml and format with our preferred YAML style
 	# using YQ because Kustomize doesn't support setting environment variables
 	$(call yq-fmt,'(select(.kind == "Deployment") | .spec.template.spec.containers[].env[] | select(.name == "OPERATOR_VERSION") | .value) = "$(VERSION)"',config/manager/manager.yaml)
-	$(call yq-fmt,'(select(.kind == "Deployment") | .spec.template.spec.containers[].env[] | select(.name == "LLAMA_STACK_VERSION") | .value) = "$(LLAMASTACK_VERSION)"',config/manager/manager.yaml)
 
 	# Generate manifests and build installer
 	$(MAKE) manifests generate

--- a/api/v1alpha1/llamastackdistribution_types.go
+++ b/api/v1alpha1/llamastackdistribution_types.go
@@ -160,8 +160,8 @@ const (
 type VersionInfo struct {
 	// OperatorVersion is the version of the operator managing this distribution
 	OperatorVersion string `json:"operatorVersion,omitempty"`
-	// DeploymentVersion is the version of the LlamaStack deployment
-	LlamaStackVersion string `json:"llamaStackServerVersion,omitempty"`
+	// LlamaStackServerVersion is the version of the LlamaStack server
+	LlamaStackServerVersion string `json:"llamaStackServerVersion,omitempty"`
 	// LastUpdated represents when the version information was last updated
 	LastUpdated metav1.Time `json:"lastUpdated,omitempty"`
 }

--- a/config/crd/bases/llamastack.io_llamastackdistributions.yaml
+++ b/config/crd/bases/llamastack.io_llamastackdistributions.yaml
@@ -2155,8 +2155,8 @@ spec:
                     format: date-time
                     type: string
                   llamaStackServerVersion:
-                    description: DeploymentVersion is the version of the LlamaStack
-                      deployment
+                    description: LlamaStackServerVersion is the version of the LlamaStack
+                      server
                     type: string
                   operatorVersion:
                     description: OperatorVersion is the version of the operator managing

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,8 +41,6 @@ spec:
         env:
         - name: OPERATOR_VERSION
           value: "latest"
-        - name: LLAMA_STACK_VERSION
-          value: "latest"
         image: controller:latest
         name: manager
         securityContext:

--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -758,6 +758,44 @@ func (r *LlamaStackDistributionReconciler) getProviderInfo(ctx context.Context, 
 	return response.Data, nil
 }
 
+// getVersionInfo makes an HTTP request to the version endpoint.
+func (r *LlamaStackDistributionReconciler) getVersionInfo(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) (string, error) {
+	u := r.getServerURL(instance, "/v1/version")
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create version request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to make version request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to query version endpoint: returned status code %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read version response: %w", err)
+	}
+
+	var response struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("failed to unmarshal version response: %w", err)
+	}
+
+	return response.Version, nil
+}
+
 // updateStatus refreshes the LlamaStack status.
 func (r *LlamaStackDistributionReconciler) updateStatus(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution, reconcileErr error) error {
 	// Initialize OperatorVersion if not set
@@ -826,9 +864,6 @@ func (r *LlamaStackDistributionReconciler) updateDeploymentStatus(ctx context.Co
 		instance.Status.Phase = llamav1alpha1.LlamaStackDistributionPhaseReady
 		deploymentReady = true
 		SetDeploymentReadyCondition(&instance.Status, true, MessageDeploymentReady)
-		if instance.Status.Version.LlamaStackVersion == "" {
-			instance.Status.Version.LlamaStackVersion = os.Getenv("LLAMA_STACK_VERSION")
-		}
 	}
 	instance.Status.AvailableReplicas = deployment.Status.ReadyReplicas
 	return deploymentReady, nil
@@ -903,6 +938,16 @@ func (r *LlamaStackDistributionReconciler) performHealthChecks(ctx context.Conte
 		instance.Status.DistributionConfig.Providers = nil
 	} else {
 		instance.Status.DistributionConfig.Providers = providers
+	}
+
+	// Get version information from the API endpoint
+	version, err := r.getVersionInfo(ctx, instance)
+	if err != nil {
+		logger.Error(err, "failed to get version info from API endpoint")
+		// Don't clear the version if we cant fetch it - keep the existing one
+	} else {
+		instance.Status.Version.LlamaStackServerVersion = version
+		logger.V(1).Info("Updated LlamaStack version from API endpoint", "version", version)
 	}
 }
 

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -214,5 +214,5 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `operatorVersion` _string_ | OperatorVersion is the version of the operator managing this distribution |  |  |
-| `llamaStackServerVersion` _string_ | DeploymentVersion is the version of the LlamaStack deployment |  |  |
+| `llamaStackServerVersion` _string_ | LlamaStackServerVersion is the version of the LlamaStack server |  |  |
 | `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#time-v1-meta)_ | LastUpdated represents when the version information was last updated |  |  |

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -2164,8 +2164,8 @@ spec:
                     format: date-time
                     type: string
                   llamaStackServerVersion:
-                    description: DeploymentVersion is the version of the LlamaStack
-                      deployment
+                    description: LlamaStackServerVersion is the version of the LlamaStack
+                      server
                     type: string
                   operatorVersion:
                     description: OperatorVersion is the version of the operator managing
@@ -2478,8 +2478,6 @@ spec:
         - /manager
         env:
         - name: OPERATOR_VERSION
-          value: latest
-        - name: LLAMA_STACK_VERSION
           value: latest
         image: quay.io/llamastack/llama-stack-k8s-operator:latest
         livenessProbe:


### PR DESCRIPTION
This commit introduces changes to set LLS version using  endpoint `/v1/version`

Resolves #86 
#### Testing

Resultant Status - 
<img width="1072" height="91" alt="Screenshot 2025-07-16 at 22 58 37" src="https://github.com/user-attachments/assets/0ae0a1f8-f6c3-4734-9a17-f2a0b90df01b" />
