### PR TITLE
feat(kustomizer): add service comparison and immutability enforcement utilities

### DIFF
--- a/pkg/compare/comparison.go
+++ b/pkg/compare/comparison.go
@@ -1,0 +1,67 @@
+package compare
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HasUnexpectedServiceChanges checks for any unexpected mutations between two Service objects.
+// It returns true and a diff string if a change is found in any field that is not
+// explicitly managed by the operator or the cluster.
+func HasUnexpectedServiceChanges(desired, current *corev1.Service) (bool, string) {
+	// Ignore fields that we are intentionally managing and expect to be different.
+	managedSpecFields := cmpopts.IgnoreFields(corev1.ServiceSpec{}, "Ports", "Selector")
+
+	// Ignore metadata fields that are managed by the Kubernetes API server.
+	// Comparing these would cause unnecessary diffs on every update.
+	clusterManagedFields := cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion", "UID", "CreationTimestamp", "Generation", "ManagedFields")
+
+	// Ignore the status field, as it is managed by the Kubernetes service controller,
+	// not by our operator.
+	ignoreStatus := cmpopts.IgnoreFields(corev1.Service{}, "Status")
+
+	diff := cmp.Diff(current, desired, managedSpecFields, clusterManagedFields, ignoreStatus)
+	if diff != "" {
+		return true, diff
+	}
+
+	return false, ""
+}
+
+// CheckAndLogServiceChanges encapsulates the full logic to fetch the current service,
+// compare it against the desired state, and log any unexpected changes.
+func CheckAndLogServiceChanges(ctx context.Context, c client.Client, desired *unstructured.Unstructured) error {
+	logger := logr.FromContextOrDiscard(ctx)
+	key := client.ObjectKeyFromObject(desired)
+	foundService := &corev1.Service{}
+
+	err := c.Get(ctx, key, foundService)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to fetch existing service for comparison: %w", err)
+	}
+
+	desiredService := &corev1.Service{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(desired.UnstructuredContent(), desiredService); err != nil {
+		return fmt.Errorf("failed to convert desired unstructured object to Service: %w", err)
+	}
+
+	changed, unexpectedChanges := HasUnexpectedServiceChanges(desiredService, foundService)
+	if changed {
+		logger.Info("Ignoring unexpected changes in Service manifest", "changes", unexpectedChanges)
+	}
+
+	return nil
+}

--- a/pkg/compare/comparison_test.go
+++ b/pkg/compare/comparison_test.go
@@ -1,0 +1,131 @@
+package compare_test
+
+import (
+	"testing"
+
+	"github.com/llamastack/llama-stack-k8s-operator/pkg/compare"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// baseService is a helper to create a consistent Service object for tests.
+func baseService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-service",
+			Namespace:       "default",
+			ResourceVersion: "1",
+			Labels: map[string]string{
+				"app": "my-app",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+			Selector: map[string]string{
+				"app": "my-app",
+			},
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: "10.0.0.1",
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{IP: "192.168.1.100"},
+				},
+			},
+		},
+	}
+}
+
+func TestHasUnexpectedServiceChanges(t *testing.T) {
+	testCases := []struct {
+		name         string
+		modifier     func(s *corev1.Service) // A function to modify the base service
+		expectChange bool
+	}{
+		{
+			name:         "no changes detected",
+			modifier:     func(s *corev1.Service) {}, // No changes
+			expectChange: false,
+		},
+		{
+			name: "only managed port changed",
+			modifier: func(s *corev1.Service) {
+				s.Spec.Ports[0].Port = 8081
+			},
+			expectChange: false,
+		},
+		{
+			name: "only managed selector changed",
+			modifier: func(s *corev1.Service) {
+				s.Spec.Selector["version"] = "v2"
+			},
+			expectChange: false,
+		},
+		{
+			name: "only cluster-managed metadata changed",
+			modifier: func(s *corev1.Service) {
+				s.ObjectMeta.ResourceVersion = "2"
+			},
+			expectChange: false,
+		},
+		{
+			name: "only status changed",
+			modifier: func(s *corev1.Service) {
+				s.Status.LoadBalancer.Ingress[0].IP = "192.168.1.101"
+			},
+			expectChange: false,
+		},
+		{
+			name: "unexpected immutable field changed - ClusterIP",
+			modifier: func(s *corev1.Service) {
+				s.Spec.ClusterIP = "10.0.0.2"
+			},
+			expectChange: true,
+		},
+		{
+			name: "unexpected field changed - ServiceType",
+			modifier: func(s *corev1.Service) {
+				s.Spec.Type = corev1.ServiceTypeNodePort
+			},
+			expectChange: true,
+		},
+		{
+			name: "combination of managed and unexpected changes",
+			modifier: func(s *corev1.Service) {
+				s.Spec.Ports[0].Port = 9000    // Managed change
+				s.Spec.ClusterIP = "10.0.0.99" // Unexpected change
+			},
+			expectChange: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			current := baseService()
+			desired := baseService()
+			tc.modifier(desired)
+
+			// Act
+			hasChanged, diff := compare.HasUnexpectedServiceChanges(desired, current)
+
+			// Assert
+			assert.Equal(t, tc.expectChange, hasChanged)
+
+			if tc.expectChange {
+				assert.NotEmpty(t, diff, "expected a diff for an unexpected change, but it was empty")
+			} else {
+				assert.Empty(t, diff, "expected no diff, but changes were detected")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduces a new `pkg/compare` package that provides utilities for detecting unexpected changes in Kubernetes Service resources by comparing desired vs current states and enforcing resource kind immutability by preventing users from mutating fields that should not be changed on existing resources. The package intelligently ignores operator-managed fields (ports, selectors) and cluster-managed metadata to focus only on detecting external mutations that could impact service functionality.