### PR TITLE
(chore) Update manager deployment spec

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,6 +42,7 @@ spec:
         - name: OPERATOR_VERSION
           value: "latest"
         image: controller:latest
+        imagePullPolicy: Always
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
@@ -65,9 +66,9 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 1Gi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 256Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -2480,6 +2480,7 @@ spec:
         - name: OPERATOR_VERSION
           value: latest
         image: quay.io/llamastack/llama-stack-k8s-operator:latest
+        imagePullPolicy: Always
         livenessProbe:
           httpGet:
             path: /healthz
@@ -2496,10 +2497,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 1Gi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
- Update memory resource limit to avoid OOMKilled error 
        - As we are watching all configmaps in cluster, we hit this error for larger clusters . We can reconfigure the values once we add optimization for ConfigMap watch.
- Update imagePullPolicy to always, for easier testing