### PR TITLE
refactor(controller): add anti-fragile test patterns and clean up utilities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,42 @@ For rapid development cycles, you can use focused test runs:
 make test TEST_PKGS=./pkg/deploy TEST_FLAGS="-v -run TestRenderManifest"
 ```
 
+## Anti-Fragile Testing Principles
+
+### Test Structure
+- **DAMP and DRY together**: Apply DAMP (Descriptive And Meaningful Phrases) to test scenarios, and DRY to implementation details. Keep test intent explicit while extracting common setup logic.
+- **Use AAA pattern**: Arrange, Act, Assert with clear comments separating each phase.
+
+### Test Data
+- **Integration tests**: Use production constants to verify the controller applies defaults correctly.
+- **E2E tests**: Use test-owned constants to focus on user workflows, not implementation details.
+- **Make test intent obvious**: Use descriptive names and explicit values that show what each test is verifying.
+
+### Test Isolation
+- **No shared state**: Each test should be independent with unique namespaces and fresh instances.
+- **Use builders for variations**: Create test instances with clear intent using the builder pattern.
+- **Async operations**: Use `require.Eventually` with appropriate timeouts for Kubernetes operations.
+
+### Example
+```go
+// Good: Descriptive test names that explain behavior
+{
+    name: "No storage configuration - should use emptyDir",
+    buildInstance: func(namespace string) *llamav1alpha1.LlamaStackDistribution {
+        return NewDistributionBuilder().
+            WithStorage(nil). // Clear intent: testing emptyDir behavior
+            Build()
+    },
+},
+
+// Bad: Vague test name that doesn't explain expected behavior
+{
+    name: "test nil storage",
+    // ...
+}
+```
+
+Focus: Tests should survive refactoring and clearly communicate what behavior they're verifying.
 
 ## Questions?
 

--- a/controllers/llamastackdistribution_controller_test.go
+++ b/controllers/llamastackdistribution_controller_test.go
@@ -1,119 +1,42 @@
-package controllers
+package controllers_test
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	llamav1alpha1 "github.com/llamastack/llama-stack-k8s-operator/api/v1alpha1"
-	"github.com/llamastack/llama-stack-k8s-operator/pkg/cluster"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	kubernetesscheme "k8s.io/client-go/kubernetes/scheme" // Alias to avoid conflict
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-)
-
-const (
-	eventuallyTimeout  = 5 * time.Second
-	eventuallyInterval = 100 * time.Millisecond
 )
 
 // testenvNamespaceCounter is used to generate unique namespace names for test isolation.
 var testenvNamespaceCounter int
 
-// baseInstance returns a minimal valid LlamaStackDistribution instance.
-// Namespace will be set to "default" and should be overridden by the caller if needed for specific test contexts.
-func baseInstance() *llamav1alpha1.LlamaStackDistribution {
-	return &llamav1alpha1.LlamaStackDistribution{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
-		},
-		Spec: llamav1alpha1.LlamaStackDistributionSpec{
-			Replicas: 1,
-			Server: llamav1alpha1.ServerSpec{
-				Distribution: llamav1alpha1.DistributionType{
-					Name: "ollama",
-				},
-				ContainerSpec: llamav1alpha1.ContainerSpec{
-					Name: llamav1alpha1.DefaultContainerName,
-					Port: llamav1alpha1.DefaultServerPort,
-				},
-			},
-		},
-	}
-}
-
-func setupTestReconciler(ctrlRuntimeClient client.Client, currentScheme *runtime.Scheme) *LlamaStackDistributionReconciler {
-	// ClusterInfo is required by the reconciler. We provide static test data for it.
-	clusterInfo := &cluster.ClusterInfo{
-		OperatorNamespace: "default",
-		DistributionImages: map[string]string{
-			"ollama": "lls/lls-ollama:1.0",
-		},
-	}
-	return &LlamaStackDistributionReconciler{
-		Client:      ctrlRuntimeClient,
-		Scheme:      currentScheme,
-		ClusterInfo: clusterInfo,
-	}
-}
-
 func TestStorageConfiguration(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
-	testEnv := &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
-		// BinaryAssetsDirectory tells envtest where to find etcd and kube-apiserver binaries.
-		// It's set from KUBEBUILDER_ASSETS, typically managed by 'make test' in Operator SDK projects,
-		// which uses setup-envtest to download project-specific Kubernetes binaries.
-		BinaryAssetsDirectory: os.Getenv("KUBEBUILDER_ASSETS"),
-	}
-
-	cfg, err := testEnv.Start()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, testEnv.Stop()) }()
-
-	// The Scheme is a registry of Go types for Kubernetes API objects. We must add all the
-	// types that ctrlRuntimeClient will interact with to this scheme so the client knows how to
-	// handle them (e.g., for Get, Create, and other operations).
-	k8sScheme := runtime.NewScheme()
-	require.NoError(t, kubernetesscheme.AddToScheme(k8sScheme))
-	require.NoError(t, llamav1alpha1.AddToScheme(k8sScheme))
-	require.NoError(t, corev1.AddToScheme(k8sScheme))
-	require.NoError(t, appsv1.AddToScheme(k8sScheme))
-	require.NoError(t, networkingv1.AddToScheme(k8sScheme))
-	require.NoError(t, rbacv1.AddToScheme(k8sScheme))
-
-	ctrlRuntimeClient, err := client.New(cfg, client.Options{Scheme: k8sScheme})
-	require.NoError(t, err)
-	require.NotNil(t, ctrlRuntimeClient)
-
 	tests := []struct {
 		name           string
-		storage        *llamav1alpha1.StorageSpec
+		buildInstance  func(namespace string) *llamav1alpha1.LlamaStackDistribution
 		expectedVolume corev1.Volume
 		expectedMount  corev1.VolumeMount
 	}{
 		{
-			name:    "No storage configuration - should use emptyDir",
-			storage: nil,
+			name: "No storage configuration - should use emptyDir",
+			buildInstance: func(namespace string) *llamav1alpha1.LlamaStackDistribution {
+				return NewDistributionBuilder().
+					WithName("test").
+					WithNamespace(namespace).
+					WithStorage(nil).
+					Build()
+			},
 			expectedVolume: corev1.Volume{
 				Name: "lls-storage",
 				VolumeSource: corev1.VolumeSource{
@@ -126,8 +49,14 @@ func TestStorageConfiguration(t *testing.T) {
 			},
 		},
 		{
-			name:    "Storage with default values",
-			storage: &llamav1alpha1.StorageSpec{},
+			name: "Storage with default values",
+			buildInstance: func(namespace string) *llamav1alpha1.LlamaStackDistribution {
+				return NewDistributionBuilder().
+					WithName("test").
+					WithNamespace(namespace).
+					WithStorage(DefaultTestStorage()).
+					Build()
+			},
 			expectedVolume: corev1.Volume{
 				Name: "lls-storage",
 				VolumeSource: corev1.VolumeSource{
@@ -143,9 +72,12 @@ func TestStorageConfiguration(t *testing.T) {
 		},
 		{
 			name: "Storage with custom values",
-			storage: &llamav1alpha1.StorageSpec{
-				Size:      resource.NewQuantity(20*1024*1024*1024, resource.BinarySI), // 20Gi
-				MountPath: "/custom/path",
+			buildInstance: func(namespace string) *llamav1alpha1.LlamaStackDistribution {
+				return NewDistributionBuilder().
+					WithName("test").
+					WithNamespace(namespace).
+					WithStorage(CustomTestStorage("20Gi", "/custom/path")).
+					Build()
 			},
 			expectedVolume: corev1.Volume{
 				Name: "lls-storage",
@@ -164,162 +96,52 @@ func TestStorageConfiguration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// envtest does not fully support namespace deletion and cleanup between test cases.
-			// To ensure test isolation and avoid interference, a unique namespace is created for each test run.
-			testenvNamespaceCounter++
-			nsName := fmt.Sprintf("test-storage-%d", testenvNamespaceCounter)
-			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
-			require.NoError(t, ctrlRuntimeClient.Create(context.Background(), ns))
+			namespace := createTestNamespace(t, "test-storage")
 
-			// Attempt to delete the namespace after the test. While envtest might not fully reclaim it,
-			// this is good practice and helps keep the test environment cleaner.
-			defer func() {
-				if err := ctrlRuntimeClient.Delete(context.Background(), ns); err != nil && !apierrors.IsNotFound(err) {
-					t.Logf("Failed to delete test namespace %s: %v", nsName, err)
-				}
-			}()
-
-			// baseInstance creates a generic LlamaStackDistribution object.
-			// The namespace is then overridden here to use the unique namespace for this test case.
-			instance := baseInstance()
-			instance.Namespace = nsName
-			instance.Spec.Server.Storage = tt.storage
-			require.NoError(t, ctrlRuntimeClient.Create(context.Background(), instance))
-
-			// Attempt to delete the LlamaStackDistribution instance after the test.
-			defer func() {
-				if err := ctrlRuntimeClient.Delete(context.Background(), instance); err != nil && !apierrors.IsNotFound(err) {
+			// arrange
+			instance := tt.buildInstance(namespace.Name)
+			require.NoError(t, k8sClient.Create(context.Background(), instance))
+			t.Cleanup(func() {
+				if err := k8sClient.Delete(context.Background(), instance); err != nil && !apierrors.IsNotFound(err) {
 					t.Logf("Failed to delete LlamaStackDistribution instance %s/%s: %v", instance.Namespace, instance.Name, err)
 				}
-			}()
-
-			// setupTestReconciler creates a reconciler instance with the real Kubernetes client and scheme provided by envtest.
-			reconciler := setupTestReconciler(ctrlRuntimeClient, k8sScheme)
-
-			_, reconcileErr := reconciler.Reconcile(context.Background(), ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      instance.Name,
-					Namespace: instance.Namespace,
-				},
 			})
-			require.NoError(t, reconcileErr, "reconcile should not fail")
 
+			// act: reconcile the instance
+			ReconcileDistribution(t, instance)
+
+			// assert
 			deployment := &appsv1.Deployment{}
-			deploymentKey := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
-			// envtest interacts with a real API server, which is eventually consistent.
-			// We use require.Eventually to poll until the Deployment becomes available.
-			require.Eventually(t, func() bool {
-				err := ctrlRuntimeClient.Get(context.Background(), deploymentKey, deployment)
-				return err == nil
-			}, eventuallyTimeout, eventuallyInterval, "timed out waiting for deployment %s to be available", deploymentKey)
+			waitForResource(t, k8sClient, instance.Namespace, instance.Name, deployment)
 
-			verifyVolume(t, deployment.Spec.Template.Spec.Volumes, tt.expectedVolume)
-			verifyVolumeMount(t, deployment.Spec.Template.Spec.Containers, tt.expectedMount)
+			if tt.expectedVolume.EmptyDir != nil {
+				AssertDeploymentUsesEmptyDirStorage(t, deployment)
+			} else if tt.expectedVolume.PersistentVolumeClaim != nil {
+				AssertDeploymentUsesPVCStorage(t, deployment, tt.expectedVolume.PersistentVolumeClaim.ClaimName)
+			}
 
-			if tt.storage != nil {
-				expectedSize := tt.storage.Size
+			AssertDeploymentHasVolumeMount(t, deployment, tt.expectedMount.MountPath)
+
+			// verify PVC is created when storage is configured
+			if instance.Spec.Server.Storage != nil {
+				expectedPVCName := tt.expectedVolume.PersistentVolumeClaim.ClaimName
+				pvc := AssertPVCExists(t, k8sClient, instance.Namespace, expectedPVCName)
+				expectedSize := instance.Spec.Server.Storage.Size
 				if expectedSize == nil {
-					expectedSize = &llamav1alpha1.DefaultStorageSize
+					AssertPVCHasSize(t, pvc, llamav1alpha1.DefaultStorageSize.String())
+				} else {
+					AssertPVCHasSize(t, pvc, expectedSize.String())
 				}
-				verifyPVC(t, ctrlRuntimeClient, instance, expectedSize)
 			}
 		})
 	}
 }
 
-func verifyVolume(t *testing.T, volumes []corev1.Volume, expectedVolume corev1.Volume) {
-	t.Helper()
-	var foundVolume *corev1.Volume
-	for _, volume := range volumes {
-		if volume.Name == expectedVolume.Name {
-			foundVolume = &volume
-			break
-		}
-	}
-	require.NotNil(t, foundVolume, "expected volume %s not found", expectedVolume.Name)
-
-	if expectedVolume.EmptyDir != nil {
-		assert.NotNil(t, foundVolume.EmptyDir, "expected emptyDir volume")
-		assert.Nil(t, foundVolume.PersistentVolumeClaim, "should not have PVC volume")
-	} else {
-		assert.NotNil(t, foundVolume.PersistentVolumeClaim, "expected PVC volume")
-		assert.Nil(t, foundVolume.EmptyDir, "should not have emptyDir volume")
-		assert.Equal(t, expectedVolume.PersistentVolumeClaim.ClaimName,
-			foundVolume.PersistentVolumeClaim.ClaimName,
-			"PVC claim name should match")
-	}
-}
-
-func verifyVolumeMount(t *testing.T, containers []corev1.Container, expectedMount corev1.VolumeMount) {
-	t.Helper()
-	var foundMount *corev1.VolumeMount
-	for _, container := range containers {
-		for _, mount := range container.VolumeMounts {
-			if mount.Name == expectedMount.Name {
-				foundMount = &mount
-				break
-			}
-		}
-	}
-	require.NotNil(t, foundMount, "expected volume mount %s not found", expectedMount.Name)
-	assert.Equal(t, expectedMount.MountPath, foundMount.MountPath, "mount path should match")
-}
-
-func verifyPVC(t *testing.T, ctrlRuntimeClient client.Client, instance *llamav1alpha1.LlamaStackDistribution, expectedSize *resource.Quantity) {
-	t.Helper()
-	pvc := &corev1.PersistentVolumeClaim{}
-	pvcKey := types.NamespacedName{Name: instance.Name + "-pvc", Namespace: instance.Namespace}
-
-	// envtest interacts with a real API server, which is eventually consistent.
-	// We use require.Eventually to poll until the PVC becomes available after reconciliation.
-	require.Eventually(t, func() bool {
-		err := ctrlRuntimeClient.Get(context.Background(), pvcKey, pvc)
-		return err == nil
-	}, eventuallyTimeout, eventuallyInterval, "timed out waiting for PVC %s to be available", pvcKey)
-
-	storageRequest, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
-	require.True(t, ok, "PVC does not have storage request")
-	assert.Equal(t, expectedSize.String(), storageRequest.String(),
-		"PVC size should match")
-}
-
 func TestConfigMapWatchingFunctionality(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
-	testEnv := &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
-		BinaryAssetsDirectory: os.Getenv("KUBEBUILDER_ASSETS"),
-	}
-
-	cfg, err := testEnv.Start()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, testEnv.Stop()) }()
-
-	// Set up the scheme
-	k8sScheme := runtime.NewScheme()
-	require.NoError(t, kubernetesscheme.AddToScheme(k8sScheme))
-	require.NoError(t, llamav1alpha1.AddToScheme(k8sScheme))
-	require.NoError(t, corev1.AddToScheme(k8sScheme))
-	require.NoError(t, appsv1.AddToScheme(k8sScheme))
-	require.NoError(t, networkingv1.AddToScheme(k8sScheme))
-
-	ctrlRuntimeClient, err := client.New(cfg, client.Options{Scheme: k8sScheme})
-	require.NoError(t, err)
-	require.NotNil(t, ctrlRuntimeClient)
-
 	// Create a test namespace
-	testenvNamespaceCounter++
-	nsName := fmt.Sprintf("test-configmap-watch-%d", testenvNamespaceCounter)
-	namespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nsName,
-		},
-	}
-	require.NoError(t, ctrlRuntimeClient.Create(context.Background(), namespace))
-	defer func() {
-		_ = ctrlRuntimeClient.Delete(context.Background(), namespace)
-	}()
+	namespace := createTestNamespace(t, "test-configmap-watch")
 
 	// Create a ConfigMap
 	configMap := &corev1.ConfigMap{
@@ -346,50 +168,23 @@ server:
   port: 8321`,
 		},
 	}
-	require.NoError(t, ctrlRuntimeClient.Create(context.Background(), configMap))
+	require.NoError(t, k8sClient.Create(context.Background(), configMap))
 
 	// Create a LlamaStackDistribution that references the ConfigMap
-	instance := &llamav1alpha1.LlamaStackDistribution{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-configmap-reference",
-			Namespace: namespace.Name,
-		},
-		Spec: llamav1alpha1.LlamaStackDistributionSpec{
-			Replicas: 1,
-			Server: llamav1alpha1.ServerSpec{
-				Distribution: llamav1alpha1.DistributionType{
-					Name: "ollama",
-				},
-				ContainerSpec: llamav1alpha1.ContainerSpec{
-					Port: 8321,
-				},
-				UserConfig: &llamav1alpha1.UserConfigSpec{
-					ConfigMapName: configMap.Name,
-				},
-			},
-		},
-	}
-	require.NoError(t, ctrlRuntimeClient.Create(context.Background(), instance))
-
-	// Set up the reconciler
-	reconciler := setupTestReconciler(ctrlRuntimeClient, k8sScheme)
+	instance := NewDistributionBuilder().
+		WithName("test-configmap-reference").
+		WithNamespace(namespace.Name).
+		WithUserConfig(configMap.Name).
+		Build()
+	require.NoError(t, k8sClient.Create(context.Background(), instance))
 
 	// Reconcile to create initial deployment
-	_, reconcileErr := reconciler.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      instance.Name,
-			Namespace: instance.Namespace,
-		},
-	})
-	require.NoError(t, reconcileErr)
+	ReconcileDistribution(t, instance)
 
 	// Get the initial deployment and check for ConfigMap hash annotation
 	deployment := &appsv1.Deployment{}
 	deploymentKey := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
-	require.Eventually(t, func() bool {
-		err := ctrlRuntimeClient.Get(context.Background(), deploymentKey, deployment)
-		return err == nil
-	}, eventuallyTimeout, eventuallyInterval)
+	waitForResourceWithKey(t, k8sClient, deploymentKey, deployment)
 
 	// Verify the ConfigMap hash annotation exists
 	initialAnnotations := deployment.Spec.Template.Annotations
@@ -398,7 +193,7 @@ server:
 	require.NotEmpty(t, initialHash, "ConfigMap hash should not be empty")
 
 	// Update the ConfigMap data
-	require.NoError(t, ctrlRuntimeClient.Get(context.Background(),
+	require.NoError(t, k8sClient.Get(context.Background(),
 		types.NamespacedName{Name: configMap.Name, Namespace: configMap.Namespace}, configMap))
 
 	configMap.Data["run.yaml"] = `version: '2'
@@ -417,30 +212,20 @@ models:
     model_type: llm
 server:
   port: 8321`
-	require.NoError(t, ctrlRuntimeClient.Update(context.Background(), configMap))
+	require.NoError(t, k8sClient.Update(context.Background(), configMap))
 
 	// Wait a moment for the watch to trigger
 	time.Sleep(2 * time.Second)
 
 	// Trigger reconciliation (in real scenarios this would be triggered by the watch)
-	_, reconcileErr = reconciler.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      instance.Name,
-			Namespace: instance.Namespace,
-		},
-	})
-	require.NoError(t, reconcileErr)
+	ReconcileDistribution(t, instance)
 
 	// Verify the deployment was updated with a new hash
-	require.Eventually(t, func() bool {
-		err := ctrlRuntimeClient.Get(context.Background(), deploymentKey, deployment)
-		if err != nil {
-			return false
-		}
-		newAnnotations := deployment.Spec.Template.Annotations
-		newHash, exists := newAnnotations["configmap.hash/user-config"]
-		return exists && newHash != initialHash && newHash != ""
-	}, eventuallyTimeout, eventuallyInterval, "ConfigMap hash should be updated after ConfigMap data change")
+	waitForResourceWithKeyAndCondition(
+		t, k8sClient, deploymentKey, deployment, func() bool {
+			newHash := deployment.Spec.Template.Annotations["configmap.hash/user-config"]
+			return newHash != initialHash && newHash != ""
+		}, "ConfigMap hash should be updated after ConfigMap data change")
 
 	t.Logf("ConfigMap hash changed from %s to %s", initialHash, deployment.Spec.Template.Annotations["configmap.hash/user-config"])
 
@@ -454,7 +239,7 @@ server:
 			"some-key": "some-value",
 		},
 	}
-	require.NoError(t, ctrlRuntimeClient.Create(context.Background(), unrelatedConfigMap))
+	require.NoError(t, k8sClient.Create(context.Background(), unrelatedConfigMap))
 
 	// Note: In test environment, field indexer might not be set up properly,
 	// so we skip the isConfigMapReferenced checks which rely on field indexing

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -18,60 +18,90 @@ package controllers_test
 
 //revive:disable:dot-imports
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	llamaxk8siov1alpha1 "github.com/llamastack/llama-stack-k8s-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+// Test infrastructure for controller tests using testify.
 
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controller Suite")
-}
+// TestMain sets up the shared test environment for controller tests.
+func TestMain(m *testing.M) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 
-var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: os.Getenv("KUBEBUILDER_ASSETS"),
 	}
 
 	var err error
-	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
+	if err != nil {
+		logf.Log.Error(err, "failed to start test environment")
+		os.Exit(1)
+	}
 
+	// Register all schemes needed by controller tests
 	err = llamaxk8siov1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		logf.Log.Error(err, "failed to add llamaxk8siov1alpha1 scheme")
+		os.Exit(1)
+	}
 
-	//+kubebuilder:scaffold:scheme
+	err = corev1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		logf.Log.Error(err, "failed to add corev1 scheme")
+		os.Exit(1)
+	}
+
+	err = appsv1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		logf.Log.Error(err, "failed to add appsv1 scheme")
+		os.Exit(1)
+	}
+
+	err = networkingv1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		logf.Log.Error(err, "failed to add networkingv1 scheme")
+		os.Exit(1)
+	}
+
+	err = rbacv1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		logf.Log.Error(err, "failed to add rbacv1 scheme")
+		os.Exit(1)
+	}
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-})
+	if err != nil {
+		logf.Log.Error(err, "failed to create client")
+		os.Exit(1)
+	}
 
-var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
-})
+	code := m.Run()
+
+	err = testEnv.Stop()
+	if err != nil {
+		logf.Log.Error(err, "failed to stop test environment")
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}

--- a/controllers/testing_support_test.go
+++ b/controllers/testing_support_test.go
@@ -1,0 +1,381 @@
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	llamav1alpha1 "github.com/llamastack/llama-stack-k8s-operator/api/v1alpha1"
+	controllers "github.com/llamastack/llama-stack-k8s-operator/controllers"
+	"github.com/llamastack/llama-stack-k8s-operator/pkg/cluster"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	testTimeout  = 5 * time.Second
+	testInterval = 100 * time.Millisecond
+
+	// Test-specific identifiers (not production defaults).
+	testImage             = "lls/lls-ollama:1.0"
+	testOperatorNamespace = "default"
+	testStorageVolumeName = "lls-storage"
+	testInstanceName      = "test-instance"
+)
+
+// DistributionBuilder - Builder pattern for test instances of operator custom resource.
+type DistributionBuilder struct {
+	instance *llamav1alpha1.LlamaStackDistribution
+}
+
+func NewDistributionBuilder() *DistributionBuilder {
+	return &DistributionBuilder{
+		instance: &llamav1alpha1.LlamaStackDistribution{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testInstanceName,
+				Namespace: "default", // Will be overridden in tests
+			},
+			Spec: llamav1alpha1.LlamaStackDistributionSpec{
+				Replicas: 1,
+				Server: llamav1alpha1.ServerSpec{
+					Distribution: llamav1alpha1.DistributionType{
+						Name: "starter", // Real distribution from distributions.json
+					},
+					ContainerSpec: llamav1alpha1.ContainerSpec{
+						Name: llamav1alpha1.DefaultContainerName,
+						Port: llamav1alpha1.DefaultServerPort,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (b *DistributionBuilder) WithName(name string) *DistributionBuilder {
+	b.instance.Name = name
+	return b
+}
+
+func (b *DistributionBuilder) WithNamespace(namespace string) *DistributionBuilder {
+	b.instance.Namespace = namespace
+	return b
+}
+
+func (b *DistributionBuilder) WithPort(port int32) *DistributionBuilder {
+	b.instance.Spec.Server.ContainerSpec.Port = port
+	return b
+}
+
+func (b *DistributionBuilder) WithReplicas(replicas int32) *DistributionBuilder {
+	b.instance.Spec.Replicas = replicas
+	return b
+}
+
+func (b *DistributionBuilder) WithStorage(storage *llamav1alpha1.StorageSpec) *DistributionBuilder {
+	b.instance.Spec.Server.Storage = storage
+	return b
+}
+
+func (b *DistributionBuilder) WithDistribution(distributionName string) *DistributionBuilder {
+	b.instance.Spec.Server.Distribution.Name = distributionName
+	return b
+}
+
+func (b *DistributionBuilder) WithResources(resources corev1.ResourceRequirements) *DistributionBuilder {
+	b.instance.Spec.Server.ContainerSpec.Resources = resources
+	return b
+}
+
+func (b *DistributionBuilder) WithServiceAccountName(serviceAccountName string) *DistributionBuilder {
+	if b.instance.Spec.Server.PodOverrides == nil {
+		b.instance.Spec.Server.PodOverrides = &llamav1alpha1.PodOverrides{}
+	}
+	b.instance.Spec.Server.PodOverrides.ServiceAccountName = serviceAccountName
+	return b
+}
+
+func (b *DistributionBuilder) WithUserConfig(configMapName string) *DistributionBuilder {
+	b.instance.Spec.Server.UserConfig = &llamav1alpha1.UserConfigSpec{
+		ConfigMapName: configMapName,
+	}
+	return b
+}
+
+func (b *DistributionBuilder) Build() *llamav1alpha1.LlamaStackDistribution {
+	return b.instance.DeepCopy()
+}
+
+func DefaultTestStorage() *llamav1alpha1.StorageSpec {
+	return &llamav1alpha1.StorageSpec{}
+}
+
+func CustomTestStorage(size string, mountPath string) *llamav1alpha1.StorageSpec {
+	sizeQuantity := resource.MustParse(size)
+	return &llamav1alpha1.StorageSpec{
+		Size:      &sizeQuantity,
+		MountPath: mountPath,
+	}
+}
+
+func AssertDeploymentHasCorrectImage(t *testing.T, deployment *appsv1.Deployment, expectedImage string) {
+	t.Helper()
+	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers,
+		"deployment should have at least one container")
+
+	actualImage := deployment.Spec.Template.Spec.Containers[0].Image
+	require.Equal(t, expectedImage, actualImage,
+		"deployment container should use the correct image")
+}
+
+func AssertDeploymentHasPort(t *testing.T, deployment *appsv1.Deployment, expectedPort int32) {
+	t.Helper()
+	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers,
+		"deployment should have at least one container")
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+	require.NotEmpty(t, container.Ports, "container should expose at least one port")
+
+	actualPort := container.Ports[0].ContainerPort
+	require.Equal(t, expectedPort, actualPort,
+		"container should expose port %d", expectedPort)
+}
+
+func AssertDeploymentUsesEmptyDirStorage(t *testing.T, deployment *appsv1.Deployment) {
+	t.Helper()
+	volume := findVolumeByName(t, deployment, testStorageVolumeName)
+	require.NotNil(t, volume.EmptyDir, "deployment should use emptyDir storage")
+	require.Nil(t, volume.PersistentVolumeClaim, "deployment should not use PVC storage")
+}
+
+func AssertDeploymentUsesPVCStorage(t *testing.T, deployment *appsv1.Deployment, expectedPVCName string) {
+	t.Helper()
+	volume := findVolumeByName(t, deployment, testStorageVolumeName)
+	require.NotNil(t, volume.PersistentVolumeClaim, "deployment should use PVC storage")
+	require.Nil(t, volume.EmptyDir, "deployment should not use emptyDir storage")
+	require.Equal(t, expectedPVCName, volume.PersistentVolumeClaim.ClaimName,
+		"deployment should reference the correct PVC")
+}
+
+func AssertDeploymentHasVolumeMount(t *testing.T, deployment *appsv1.Deployment, expectedMountPath string) {
+	t.Helper()
+	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers,
+		"deployment should have at least one container")
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+	mount := findVolumeMountByName(t, container, testStorageVolumeName)
+	require.Equal(t, expectedMountPath, mount.MountPath,
+		"volume should be mounted at the correct path")
+}
+
+func AssertPVCExists(t *testing.T, client client.Client, namespace, name string) *corev1.PersistentVolumeClaim {
+	t.Helper()
+	pvc := &corev1.PersistentVolumeClaim{}
+	key := types.NamespacedName{Name: name, Namespace: namespace}
+
+	require.Eventually(t, func() bool {
+		return client.Get(context.Background(), key, pvc) == nil
+	}, testTimeout, testInterval, "PVC %s should exist in namespace %s", name, namespace)
+
+	return pvc
+}
+
+func AssertServiceExposesDeployment(t *testing.T, service *corev1.Service, deployment *appsv1.Deployment) {
+	t.Helper()
+
+	// Behavior: Service should target deployment pods via selectors
+	require.Equal(t, service.Spec.Selector, deployment.Spec.Template.Labels,
+		"service selector should match deployment pod labels for traffic routing")
+
+	// Behavior: Service port should route to deployment container port
+	require.NotEmpty(t, service.Spec.Ports, "service should expose at least one port")
+	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers, "deployment should have at least one container")
+
+	servicePort := service.Spec.Ports[0]
+	containerPort := deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort
+	require.Equal(t, servicePort.TargetPort.IntVal, containerPort,
+		"service target port should route to deployment container port")
+}
+
+func AssertNetworkPolicyProtectsDeployment(t *testing.T, networkPolicy *networkingv1.NetworkPolicy, deployment *appsv1.Deployment) {
+	t.Helper()
+
+	// Behavior: NetworkPolicy should target the same pods as deployment
+	require.Equal(t, deployment.Spec.Template.Labels, networkPolicy.Spec.PodSelector.MatchLabels,
+		"network policy should protect the same pods as deployment")
+
+	// Behavior: NetworkPolicy should allow traffic on deployment container port
+	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers, "deployment should have containers")
+	require.NotEmpty(t, networkPolicy.Spec.Ingress, "network policy should have ingress rules")
+	require.NotEmpty(t, networkPolicy.Spec.Ingress[0].Ports, "network policy should allow specific ports")
+
+	containerPort := deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort
+	policyPort := networkPolicy.Spec.Ingress[0].Ports[0].Port.IntVal
+	require.Equal(t, containerPort, policyPort,
+		"network policy should allow traffic on deployment container port")
+}
+
+func AssertResourceOwnedByInstance(t *testing.T, resource metav1.Object, instance *llamav1alpha1.LlamaStackDistribution) {
+	t.Helper()
+
+	// Behavior: Resource should be owned by the LlamaStackDistribution instance
+	ownerRefs := resource.GetOwnerReferences()
+	require.Len(t, ownerRefs, 1, "resource should have exactly one owner reference")
+	require.Equal(t, instance.GetUID(), ownerRefs[0].UID,
+		"resource should be owned by the LlamaStackDistribution instance for garbage collection")
+}
+
+func AssertClusterRoleBindingLinksServiceAccount(t *testing.T, crb *rbacv1.ClusterRoleBinding, serviceAccount *corev1.ServiceAccount) {
+	t.Helper()
+
+	// Behavior: ClusterRoleBinding should grant permissions to the ServiceAccount
+	require.NotEmpty(t, crb.Subjects, "cluster role binding should have subjects")
+
+	found := false
+	for _, subject := range crb.Subjects {
+		if subject.Kind == "ServiceAccount" &&
+			subject.Name == serviceAccount.Name &&
+			subject.Namespace == serviceAccount.Namespace {
+			found = true
+			break
+		}
+	}
+	require.True(t, found,
+		"cluster role binding should grant permissions to the service account %s/%s",
+		serviceAccount.Namespace, serviceAccount.Name)
+}
+
+func AssertDeploymentUsesServiceAccount(t *testing.T, deployment *appsv1.Deployment, serviceAccount *corev1.ServiceAccount) {
+	t.Helper()
+
+	// Behavior: Deployment should use the ServiceAccount for pod identity
+	require.Equal(t, serviceAccount.Name, deployment.Spec.Template.Spec.ServiceAccountName,
+		"deployment pods should use the service account for proper permissions")
+}
+
+func AssertPVCHasSize(t *testing.T, pvc *corev1.PersistentVolumeClaim, expectedSize string) {
+	t.Helper()
+	storageRequest, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	require.True(t, ok, "PVC should have storage request")
+
+	expectedQuantity := resource.MustParse(expectedSize)
+	require.True(t, expectedQuantity.Equal(storageRequest),
+		"PVC should request %s storage, got %s", expectedSize, storageRequest.String())
+}
+
+func ReconcileDistribution(t *testing.T, instance *llamav1alpha1.LlamaStackDistribution) {
+	t.Helper()
+	// Create reconciler and run reconciliation
+	reconciler := createTestReconciler()
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		},
+	})
+	require.NoError(t, err, "reconciliation should succeed")
+}
+
+func ResourceTestName(instanceName, suffix string) string {
+	return instanceName + suffix
+}
+
+func createTestReconciler() *controllers.LlamaStackDistributionReconciler {
+	clusterInfo := &cluster.ClusterInfo{
+		OperatorNamespace: testOperatorNamespace,
+		DistributionImages: map[string]string{
+			"starter": testImage, // Use same distribution as builder
+		},
+	}
+	return &controllers.LlamaStackDistributionReconciler{
+		Client:      k8sClient,
+		Scheme:      scheme.Scheme,
+		ClusterInfo: clusterInfo,
+	}
+}
+
+func findVolumeByName(t *testing.T, deployment *appsv1.Deployment, volumeName string) *corev1.Volume {
+	t.Helper()
+	for _, volume := range deployment.Spec.Template.Spec.Volumes {
+		if volume.Name == volumeName {
+			return &volume
+		}
+	}
+	require.Fail(t, "volume not found", "deployment should have volume named %s", volumeName)
+	return nil
+}
+
+func findVolumeMountByName(t *testing.T, container corev1.Container, volumeName string) *corev1.VolumeMount {
+	t.Helper()
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == volumeName {
+			return &mount
+		}
+	}
+	require.Fail(t, "volume mount not found", "container should have volume mount named %s", volumeName)
+	return nil
+}
+
+// waitForResource waits for a resource to exist (convenience version).
+func waitForResource(t *testing.T, client client.Client, namespace, name string, resource client.Object) {
+	t.Helper()
+	key := types.NamespacedName{Name: name, Namespace: namespace}
+	waitForResourceWithKey(t, client, key, resource)
+}
+
+// waitForResourceWithKey waits for a resource using an existing NamespacedName.
+func waitForResourceWithKey(t *testing.T, client client.Client, key types.NamespacedName, resource client.Object) {
+	t.Helper()
+	waitForResourceWithKeyAndCondition(t, client, key, resource, nil, fmt.Sprintf("timed out waiting for %T %s to be available", resource, key))
+}
+
+// waitForResourceWithKeyAndCondition provides the full flexibility for complex conditions.
+func waitForResourceWithKeyAndCondition(t *testing.T, client client.Client, key types.NamespacedName, resource client.Object, condition func() bool, message string) {
+	t.Helper()
+	// envtest interacts with a real API server, which is eventually consistent.
+	require.Eventually(t, func() bool {
+		err := client.Get(context.Background(), key, resource)
+		if err != nil {
+			return false
+		}
+		// If no condition specified, just check existence
+		if condition == nil {
+			return true
+		}
+		// Otherwise check the custom condition
+		return condition()
+	}, testTimeout, testInterval, message)
+}
+
+// createTestNamespace creates a unique test namespace and registers cleanup.
+func createTestNamespace(t *testing.T, namePrefix string) *corev1.Namespace {
+	t.Helper()
+	// envtest does not fully support namespace deletion and cleanup between test cases.
+	// To ensure test isolation and avoid interference, a unique namespace is created for each test run.
+	testenvNamespaceCounter++
+	nsName := fmt.Sprintf("%s-%d", namePrefix, testenvNamespaceCounter)
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+		},
+	}
+	require.NoError(t, k8sClient.Create(context.Background(), namespace))
+
+	// Attempt to delete the namespace after the test. While envtest might not fully reclaim it,
+	// this is good practice and helps keep the test environment cleaner.
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(context.Background(), namespace); err != nil {
+			t.Logf("Failed to delete test namespace %s: %v", namespace.Name, err)
+		}
+	})
+	return namespace
+}


### PR DESCRIPTION
Refactor controller tests to use `controllers_test` package with shared envtest environment. This consolidates test environment setup in `suite_test.go` using `TestMain` and adds anti-fragile testing patterns including a DistributionBuilder, consolidated test constants, and behavioral helpers. This pull request also documents the intent behind these changes in `CONTRIBUTING.md`.

This is intended to facilitate an upcoming pull request to add a `TestReconcile()` to the controller's test suite to more fully cover the controller's happy path to reconciliation.