### PR TITLE
fix: vllm deployment script runAsNonRoot update

### DIFF
--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -135,7 +135,7 @@ generate_security_context() {
         # For vLLM, use restricted-v2 SCC annotation (do not create new SCC resource)
         SECURITY_CONTEXT_YAML=""
         CONTAINER_SECURITY_CONTEXT_YAML="securityContext:
-            runAsNonRoot: true"
+            runAsNonRoot: false"
 
         # Add annotation for restricted-v2 SCC to deployment
         if kubectl api-resources --api-group=security.openshift.io | grep -iq 'SecurityContextConstraints'; then


### PR DESCRIPTION
Setting `runAsNonRoot` to false for kubernetes clusters. The deployment issue currently happens on EKS and GKE clusters without this setting.

Closes #125 