### PR TITLE
feat: Create workflow to generate + publish vLLM CPU image for E2E testing

### DIFF
--- a/.github/workflows/build-vllm-cpu-image.yml
+++ b/.github/workflows/build-vllm-cpu-image.yml
@@ -1,0 +1,54 @@
+name: Build CPU-only vLLM Image
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+env:
+  VLLM_CPU_IMAGE: "quay.io/llamastack/vllm-cpu"
+
+jobs:
+  build-latest-vllm-cpu-image:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+      # We need to clone vLLM first to identify latest tags unless we want to use the GH API.
+      - name: Clone vLLM
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with: 
+          repository: vllm-project/vllm
+          path: vllm
+          fetch-depth: 0 # Fetch all history to find the latest tag
+
+      - name: Get latest vLLM release tag
+        id: get_latest_vllm_release
+        run: |
+          cd vllm
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "::set-output name=tag::${LATEST_TAG}"
+
+      - name: Checkout latest vLLM release
+        run: cd vllm && git checkout tags/${{ steps.get_latest_vllm_release.outputs.tag }}
+        shell: bash
+
+      - name: Login to Quay.io
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.APP_QUAY_USERNAME }}
+          password: ${{ secrets.APP_QUAY_TOKEN }}
+
+      - name: Build and push latest vLLM CPU image
+        run: |
+           podman build --security-opt label=disable -f docker/Dockerfile.cpu --build-arg VLLM_CPU_AVX512BF16=false  --build-arg VLLM_CPU_AVX512VNNI=false --tag ${VLLM_CPU_IMAGE}:latest --target vllm-openai .
+           podman tag ${VLLM_CPU_IMAGE}:${{ steps.get_latest_vllm_release.outputs.tag }}
+           make image-push -e IMG=${VLLM_CPU_IMAGE}:latest
+           make image-push -e IMG=${VLLM_CPU_IMAGE}:${{ steps.get_latest_vllm_release.outputs.tag }}
+        shell: bash

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -70,8 +70,12 @@ get_provider_config() {
             echo "HEALTH_PATH=/api/version"
             echo "DEFAULT_ENV_VARS=OLLAMA_KEEP_ALIVE=60m"
             ;;
-        "vllm")
-            echo "IMAGE=vllm/vllm-openai:latest"
+        "vllm" | "vllm-cpu")
+            if [[ "${provider}" == "vllm"]]; then
+                echo "IMAGE=vllm/vllm-openai:latest"
+            else
+                echo "IMAGE=quay.io/llamastack/vllm-cpu:latest"
+            fi
             echo "INFERENCE_SERVER=vllm"
             echo "COMMAND=[\"/bin/sh\", \"-c\"]"
             echo "DEFAULT_MODEL=meta-llama/Llama-3.2-1B"


### PR DESCRIPTION
Create a new GitHub workflow that generates and publishes a CPU-only vLLM image for local dev E2E testing.

Resolves #128 