### PR TITLE
fix: updating CRD names; including llds editor/viewer roles

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -19,3 +19,5 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- llsd_viewer_role.yaml
+- llsd_editor_role.yaml

--- a/config/rbac/llsd_editor_role.yaml
+++ b/config/rbac/llsd_editor_role.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: llsd-editor-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - apiGroups:
   - llamastack.io

--- a/config/rbac/llsd_editor_role.yaml
+++ b/config/rbac/llsd_editor_role.yaml
@@ -1,20 +1,24 @@
-# permissions for end users to view llamastacks.
+# permissions for end users to edit LlamaStackDistributions.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: llamastack-viewer-role
+  name: llsd-editor-role
 rules:
 - apiGroups:
   - llamastack.io
   resources:
-  - llamastacks
+  - llamastackdistributions
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - llamastack.io
   resources:
-  - llamastacks/status
+  - llamastackdistributions/status
   verbs:
   - get

--- a/config/rbac/llsd_viewer_role.yaml
+++ b/config/rbac/llsd_viewer_role.yaml
@@ -1,24 +1,20 @@
-# permissions for end users to edit llamastacks.
+# permissions for end users to view LlamaStackDistributions.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: llamastack-editor-role
+  name: llsd-viewer-role
 rules:
 - apiGroups:
   - llamastack.io
   resources:
-  - llamastacks
+  - llamastackdistributions
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - llamastack.io
   resources:
-  - llamastacks/status
+  - llamastackdistributions/status
   verbs:
   - get

--- a/config/rbac/llsd_viewer_role.yaml
+++ b/config/rbac/llsd_viewer_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: llsd-viewer-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups:
   - llamastack.io

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -2268,6 +2268,8 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: llama-stack-k8s-operator
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: llama-stack-k8s-operator-llsd-editor-role
 rules:
 - apiGroups:
@@ -2294,6 +2296,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: llama-stack-k8s-operator
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: llama-stack-k8s-operator-llsd-viewer-role
 rules:
 - apiGroups:

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -2268,6 +2268,54 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: llama-stack-k8s-operator
+  name: llama-stack-k8s-operator-llsd-editor-role
+rules:
+- apiGroups:
+  - llamastack.io
+  resources:
+  - llamastackdistributions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - llamastack.io
+  resources:
+  - llamastackdistributions/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+  name: llama-stack-k8s-operator-llsd-viewer-role
+rules:
+- apiGroups:
+  - llamastack.io
+  resources:
+  - llamastackdistributions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - llamastack.io
+  resources:
+  - llamastackdistributions/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
   name: llama-stack-k8s-operator-manager-role
 rules:
 - apiGroups:


### PR DESCRIPTION
Adds a reference to the config/rbac/llsd_editor_role.yaml and config/rbac/llsd_viewer_role.yaml files to config/rbac/kustomization.yaml so the ClusterRoles get created upon installation.

Fixes: RHAIENG-496