### PR TITLE
feat: bump build container ubi version to 9 to match run container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG GOLANG_VERSION=1.23
 
-FROM registry.access.redhat.com/ubi8/go-toolset:${GOLANG_VERSION} as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:${GOLANG_VERSION} as builder
 ARG TARGETOS=linux
 ARG TARGETARCH
 ARG CGO_ENABLED=0


### PR DESCRIPTION
Making `base` image consistent with `run` image. It will also make it easier to adopt additional FIPS-specific build options in the future, if needed.