### PR TITLE
fix: Remove 'if' conditional for vLLM CPU build job

### DIFF
--- a/.github/workflows/build-vllm-cpu-image.yml
+++ b/.github/workflows/build-vllm-cpu-image.yml
@@ -12,7 +12,6 @@ env:
 
 jobs:
   build-latest-vllm-cpu-image:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
Remove the `if` conditional that prevents manual testing through `workflow_dispatch`.