### PR TITLE
fix: Change to 'vllm' dir to build vLLM CPU image

### DIFF
--- a/.github/workflows/build-vllm-cpu-image.yml
+++ b/.github/workflows/build-vllm-cpu-image.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Build and push latest vLLM CPU image
         run: |
+           cd vllm
            podman build --security-opt label=disable -f docker/Dockerfile.cpu --build-arg VLLM_CPU_AVX512BF16=false  --build-arg VLLM_CPU_AVX512VNNI=false --tag ${VLLM_CPU_IMAGE}:latest --target vllm-openai .
            podman tag ${VLLM_CPU_IMAGE}:${{ steps.get_latest_vllm_release.outputs.tag }}
            make image-push -e IMG=${VLLM_CPU_IMAGE}:latest


### PR DESCRIPTION
Without `cd`, GitHub Actions tries to look for `Dockerfile.cpu` in the local repository instead of the cloned `vllm` repository, where it's actually located.