### PR TITLE
fix: Correct `podman tag` command

### DIFF
--- a/.github/workflows/build-vllm-cpu-image.yml
+++ b/.github/workflows/build-vllm-cpu-image.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
            cd vllm
            podman build --security-opt label=disable -f docker/Dockerfile.cpu --build-arg VLLM_CPU_AVX512BF16=false  --build-arg VLLM_CPU_AVX512VNNI=false --tag ${VLLM_CPU_IMAGE}:latest --target vllm-openai .
-           podman tag ${VLLM_CPU_IMAGE}:${{ steps.get_latest_vllm_release.outputs.tag }}
+           podman tag ${VLLM_CPU_IMAGE}:latest ${VLLM_CPU_IMAGE}:${{ steps.get_latest_vllm_release.outputs.tag }}
            make image-push -e IMG=${VLLM_CPU_IMAGE}:latest
            make image-push -e IMG=${VLLM_CPU_IMAGE}:${{ steps.get_latest_vllm_release.outputs.tag }}
         shell: bash


### PR DESCRIPTION
The original `podman tag` command did not include the original image name and original image tag, so Podman didn't know which image to tag as 'vllm-cpu'