### PR TITLE
fix: Call `make` from the `llama-stack-k8s-operator` dir, not the `vllm` dir

### DIFF
--- a/.github/workflows/build-vllm-cpu-image.yml
+++ b/.github/workflows/build-vllm-cpu-image.yml
@@ -48,6 +48,7 @@ jobs:
            cd vllm
            podman build --security-opt label=disable -f docker/Dockerfile.cpu --build-arg VLLM_CPU_AVX512BF16=false  --build-arg VLLM_CPU_AVX512VNNI=false --tag ${VLLM_CPU_IMAGE}:latest --target vllm-openai .
            podman tag ${VLLM_CPU_IMAGE}:latest ${VLLM_CPU_IMAGE}:${{ steps.get_latest_vllm_release.outputs.tag }}
+           cd ..
            make image-push -e IMG=${VLLM_CPU_IMAGE}:latest
            make image-push -e IMG=${VLLM_CPU_IMAGE}:${{ steps.get_latest_vllm_release.outputs.tag }}
         shell: bash


### PR DESCRIPTION
The `image-push` target exists in the `llama-stack-k8s-operator` dir, not the `vllm` dir. Therefore, in order to call the `image-push` target, we need to `cd ..` to the main directory where the appropriate Makefile exists.