### PR TITLE
feat: Refuse to overwrite `latest` vllm-cpu image on alpha, beta, or rc tag.

### DIFF
--- a/.github/workflows/build-vllm-cpu-image.yml
+++ b/.github/workflows/build-vllm-cpu-image.yml
@@ -1,6 +1,11 @@
 name: Build CPU-only vLLM Image
 
 on:
+  # Because it is challenging to trigger this workflow every time the vLLM
+  # maintainers publish a new release/tag, we can at least setup a cronjob
+  # to update the image once a week.
+  schedule:
+    - cron: '0 0 * * FRI' # Runs at 12AM UTC on Fridays
   workflow_dispatch:
 
 permissions:
@@ -46,9 +51,14 @@ jobs:
       - name: Build and push latest vLLM CPU image
         run: |
            cd vllm
-           podman build --security-opt label=disable -f docker/Dockerfile.cpu --build-arg VLLM_CPU_AVX512BF16=false  --build-arg VLLM_CPU_AVX512VNNI=false --tag ${VLLM_CPU_IMAGE}:latest --target vllm-openai .
-           podman tag ${VLLM_CPU_IMAGE}:latest ${VLLM_CPU_IMAGE}:${{ steps.get_latest_vllm_release.outputs.tag }}
+           export vllm_version="${{ steps.get_latest_vllm_release.outputs.tag }}"
+           podman build --security-opt label=disable -f docker/Dockerfile.cpu --build-arg VLLM_CPU_AVX512BF16=false  --build-arg VLLM_CPU_AVX512VNNI=false --tag ${VLLM_CPU_IMAGE}:${vllm_version} --target vllm-openai .
+           make image-push -e IMG=${VLLM_CPU_IMAGE}:${vllm_version}
            cd ..
-           make image-push -e IMG=${VLLM_CPU_IMAGE}:latest
-           make image-push -e IMG=${VLLM_CPU_IMAGE}:${{ steps.get_latest_vllm_release.outputs.tag }}
+           if [[ "$vllm_version" =~ [Aa] ]] || [[ "$vllm_version" =~ [Bb] ]] || [[ "$vllm_version" =~ [Rr]c ]]; then
+             echo "Image succesfully pushed to quay.io, but refusing to overwrite the `latest` tag with for vLLM ${vllm_version} because it is either an alpha, beta, or release candidate."
+           else
+             podman tag ${VLLM_CPU_IMAGE}:${vllm_version} ${VLLM_CPU_IMAGE}:latest
+             make image-push -e IMG=${VLLM_CPU_IMAGE}:latest
+           fi
         shell: bash


### PR DESCRIPTION
We still want to push alpha, beta, and rc images to our quay.io repo, but we don't necessarily want to overwrite the `latest` tag with an alpha, beta, or rc version.

Also schedule this job for once a week, on Fridays, at 12am UTC.