### PR TITLE
feat(controller): implement NetworkPolicy pruning for disabled features

### DIFF
--- a/controllers/llamastackdistribution_controller_test.go
+++ b/controllers/llamastackdistribution_controller_test.go
@@ -272,8 +272,9 @@ func TestReconcile(t *testing.T) {
 		TargetPort: intstr.FromInt(int(instancePort)),
 		Protocol:   corev1.ProtocolTCP,
 	}
-	operatorNamespaceName := "test-operator-namespace"
+	enableNetworkPolicy := true
 
+	operatorNamespaceName := "test-operator-namespace"
 	// set operator namespace to avoid service account file dependency
 	t.Setenv("OPERATOR_NAMESPACE", operatorNamespaceName)
 
@@ -287,7 +288,7 @@ func TestReconcile(t *testing.T) {
 	require.NoError(t, k8sClient.Create(context.Background(), instance))
 
 	// --- act ---
-	ReconcileDistribution(t, instance, true)
+	ReconcileDistribution(t, instance, enableNetworkPolicy)
 
 	service := &corev1.Service{}
 	waitForResource(t, k8sClient, instance.Namespace, instance.Name+"-service", service)

--- a/controllers/manifests/base/kustomization.yaml
+++ b/controllers/manifests/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - serviceaccount.yaml
 - scc-binding.yaml
 - service.yaml
+- networkpolicy.yaml
 
 labels:
 - includeSelectors: false

--- a/controllers/manifests/base/networkpolicy.yaml
+++ b/controllers/manifests/base/networkpolicy.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-policy
+spec:
+  podSelector:
+    matchLabels:
+      # app: llama-stack
+      # app.kubernetes.io/instance: llamastackdistribution-sample
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/part-of: llama-stack
+      namespaceSelector: {}
+    ports:
+    - protocol: TCP
+  - from:
+    - podSelector: {}
+      namespaceSelector: {}
+    ports:
+    - protocol: TCP

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	llamav1alpha1 "github.com/llamastack/llama-stack-k8s-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,7 +23,7 @@ func ApplyDeployment(ctx context.Context, cli client.Client, scheme *runtime.Sch
 
 	found := &appsv1.Deployment{}
 	err := cli.Get(ctx, client.ObjectKeyFromObject(deployment), found)
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && k8serrors.IsNotFound(err) {
 		logger.Info("Creating Deployment", "deployment", deployment.Name)
 		return cli.Create(ctx, deployment)
 	} else if err != nil {

--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -62,6 +62,7 @@ func setupApplyResourcesTest(t *testing.T, ownerName string) (context.Context, s
 
 // TestRenderManifest contains all unit tests for the RenderManifest function.
 func TestRenderManifest(t *testing.T) {
+	t.Setenv("OPERATOR_NAMESPACE", "default")
 	t.Run("should render correctly with a standard layout", func(t *testing.T) {
 		// given an-memory filesystem with a standard kustomize layout
 		fsys := filesys.MakeFsInMemory()


### PR DESCRIPTION
Add pruneExcludedResources function to automatically delete NetworkPolicy resources when EnableNetworkPolicy feature is disabled. This ensures TestNetworkPolicyConfiguration passes by properly cleaning up resources during feature toggles.

- Add pruning logic that reuses existing HandleDisabledNetworkPolicy
- Remove obsolete commented reconcileNetworkPolicy function
- Integrate pruning into reconcileManifestResources before applying manifests