### PR TITLE
standardize DfFIPS settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ ARG GOLANG_VERSION=1.23
 FROM registry.access.redhat.com/ubi8/go-toolset:${GOLANG_VERSION} as builder
 ARG TARGETOS=linux
 ARG TARGETARCH
-ARG CGO_ENABLED=0
+ARG CGO_ENABLED=1
+ARG GOTAGS=strictfipsruntime,openssl
+ENV GOEXPERIMENT=strictfipsruntime
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -26,7 +28,7 @@ USER root
 
 # GOARCH is intentionally left empty to automatically detect the host architecture
 # This ensures the binary matches the platform where image-build is executed
-RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -tags=${GOTAGS} -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
@@ -34,6 +36,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/controllers/manifests ./manifests/
+RUN microdnf install -y openssl && microdnf clean all
 USER 1001
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Updating relevant settings to make the same DfFIPS configurations on some other RHOAI components, for the purpose of passing [check-payload](https://github.com/openshift/check-payload/) scans without errors or false-positives.

- CGO settings updated
- Golang version incremented
- Some context / test changes  made to accommodate the Go version update.

Fixes: RHAIENG-663

If merged before 139, then bumps the UBI of the builder image, and:
Closes: #139 