### PR TITLE
fix: adapt the container entrypoint based on the llama-stack version

### DIFF
--- a/controllers/resource_helper_test.go
+++ b/controllers/resource_helper_test.go
@@ -160,8 +160,8 @@ func TestBuildContainerSpec(t *testing.T) {
 				ImagePullPolicy: corev1.PullAlways,
 				Ports:           []corev1.ContainerPort{{ContainerPort: llamav1alpha1.DefaultServerPort}},
 				ReadinessProbe:  newDefaultReadinessProbe(llamav1alpha1.DefaultServerPort),
-				Command:         []string{"python", "-m", "llama_stack.distribution.server.server"},
-				Args:            []string{"--config", "/etc/llama-stack/run.yaml"},
+				Command:         []string{"/bin/sh", "-c", startupScript},
+				Args:            []string{},
 				Env: []corev1.EnvVar{
 					{Name: "HF_HOME", Value: llamav1alpha1.DefaultMountPath},
 				},


### PR DESCRIPTION
In llama-stack 0.2.17, with the help of
https://github.com/llamastack/llama-stack/pull/2975 the module name containing the server changed. So we need to adapt the entrypoint in consequence.

When using a ConfigMap to store the server configuration, the operator overrides the container entrypoint. This code has been adapted to use the correct module based on the detected llama-stack version.

Also, we now force the entrypoint to use python3 instead of python.