### PR TITLE
feat: disable readiness probe and add startup probe

### DIFF
--- a/controllers/resource_helper_test.go
+++ b/controllers/resource_helper_test.go
@@ -49,10 +49,10 @@ func TestBuildContainerSpec(t *testing.T) {
 			},
 			image: "test-image:latest",
 			expectedResult: corev1.Container{
-				Name:           llamav1alpha1.DefaultContainerName,
-				Image:          "test-image:latest",
-				Ports:          []corev1.ContainerPort{{ContainerPort: llamav1alpha1.DefaultServerPort}},
-				ReadinessProbe: newDefaultReadinessProbe(llamav1alpha1.DefaultServerPort),
+				Name:         llamav1alpha1.DefaultContainerName,
+				Image:        "test-image:latest",
+				Ports:        []corev1.ContainerPort{{ContainerPort: llamav1alpha1.DefaultServerPort}},
+				StartupProbe: newDefaultStartupProbe(llamav1alpha1.DefaultServerPort),
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      "lls-storage",
 					MountPath: llamav1alpha1.DefaultMountPath,
@@ -88,10 +88,10 @@ func TestBuildContainerSpec(t *testing.T) {
 			},
 			image: "test-image:latest",
 			expectedResult: corev1.Container{
-				Name:           "custom-container",
-				Image:          "test-image:latest",
-				Ports:          []corev1.ContainerPort{{ContainerPort: 9000}},
-				ReadinessProbe: newDefaultReadinessProbe(9000),
+				Name:         "custom-container",
+				Image:        "test-image:latest",
+				Ports:        []corev1.ContainerPort{{ContainerPort: 9000}},
+				StartupProbe: newDefaultStartupProbe(9000),
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("1"),
@@ -123,12 +123,12 @@ func TestBuildContainerSpec(t *testing.T) {
 			},
 			image: "test-image:latest",
 			expectedResult: corev1.Container{
-				Name:           llamav1alpha1.DefaultContainerName,
-				Image:          "test-image:latest",
-				Command:        []string{"/custom/entrypoint.sh"},
-				Args:           []string{"--config", "/etc/config.yaml", "--debug"},
-				Ports:          []corev1.ContainerPort{{ContainerPort: llamav1alpha1.DefaultServerPort}},
-				ReadinessProbe: newDefaultReadinessProbe(llamav1alpha1.DefaultServerPort),
+				Name:         llamav1alpha1.DefaultContainerName,
+				Image:        "test-image:latest",
+				Command:      []string{"/custom/entrypoint.sh"},
+				Args:         []string{"--config", "/etc/config.yaml", "--debug"},
+				Ports:        []corev1.ContainerPort{{ContainerPort: llamav1alpha1.DefaultServerPort}},
+				StartupProbe: newDefaultStartupProbe(llamav1alpha1.DefaultServerPort),
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      "lls-storage",
 					MountPath: llamav1alpha1.DefaultMountPath,
@@ -159,7 +159,7 @@ func TestBuildContainerSpec(t *testing.T) {
 				Image:           "test-image:latest",
 				ImagePullPolicy: corev1.PullAlways,
 				Ports:           []corev1.ContainerPort{{ContainerPort: llamav1alpha1.DefaultServerPort}},
-				ReadinessProbe:  newDefaultReadinessProbe(llamav1alpha1.DefaultServerPort),
+				StartupProbe:    newDefaultStartupProbe(llamav1alpha1.DefaultServerPort),
 				Command:         []string{"/bin/sh", "-c", startupScript},
 				Args:            []string{},
 				Env: []corev1.EnvVar{
@@ -191,7 +191,7 @@ func TestBuildContainerSpec(t *testing.T) {
 			assert.Equal(t, tc.expectedResult.VolumeMounts, result.VolumeMounts)
 			assert.Equal(t, tc.expectedResult.Command, result.Command)
 			assert.Equal(t, tc.expectedResult.Args, result.Args)
-			assert.Equal(t, tc.expectedResult.ReadinessProbe, result.ReadinessProbe)
+			assert.Equal(t, tc.expectedResult.StartupProbe, result.StartupProbe)
 		})
 	}
 }
@@ -647,10 +647,10 @@ func TestValidateConfigMapKeys(t *testing.T) {
 	}
 }
 
-// newDefaultReadinessProbe returns a Kubernetes HTTP readiness probe that checks
+// newDefaultStartupProbe returns a Kubernetes HTTP readiness probe that checks
 // the "/v1/health" endpoint on the given port using default timing and
 // threshold settings.
-func newDefaultReadinessProbe(port int32) *corev1.Probe {
+func newDefaultStartupProbe(port int32) *corev1.Probe {
 	return &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -658,10 +658,9 @@ func newDefaultReadinessProbe(port int32) *corev1.Probe {
 				Port: intstr.FromInt(int(port)),
 			},
 		},
-		InitialDelaySeconds: readinessProbeInitialDelaySeconds,
-		PeriodSeconds:       readinessProbePeriodSeconds,
-		TimeoutSeconds:      readinessProbeTimeoutSeconds,
-		FailureThreshold:    readinessProbeFailureThreshold,
-		SuccessThreshold:    readinessProbeSuccessThreshold,
+		InitialDelaySeconds: startupProbeInitialDelaySeconds,
+		TimeoutSeconds:      startupProbeTimeoutSeconds,
+		FailureThreshold:    startupProbeFailureThreshold,
+		SuccessThreshold:    startupProbeSuccessThreshold,
 	}
 }


### PR DESCRIPTION
Problem: The current readiness probe fails during documentation ingestion because the endpoint is blocked by synchronous code. This causes the pod to flap in and out of service, even though the process itself is healthy and simply busy. Ending up with pod restart since the Readiness probe keeps failing.

Solution: Replace the readiness probe with a startup probe. This allows the pod to survive long ingestion periods without being prematurely marked unready by Kubernetes. We disable the Readiness probe for now but still ensure some basic health functionality for startup.

Tradeoff: Once the startup probe succeeds, Kubernetes will assume the pod remains ready for traffic. This means we lose the ongoing readiness check and a pod that later becomes overloaded or blocked will still receive traffic until the liveness probe detects a failure. I'm accepting this tradeoff to eliminate flakiness during ingestion, as rewriting the app to be async or decoupling health checks is not feasible right now.

What's next: once llama-stack has fixed the code to be async we could re-enable the Readiness probes.

Other options considered:

* Ability to disable Readiness probe via CRD flag, feels invasive
* Tweak the Readiness probe, we will never get it right, it will work sometimes but will end up being flaky during ingestion.