### PR TITLE
test: remove ollama distribution testing, replace with starter

### DIFF
--- a/config/samples/_v1alpha1_llamastackdistribution.yaml
+++ b/config/samples/_v1alpha1_llamastackdistribution.yaml
@@ -13,7 +13,7 @@ spec:
           value: 'http://ollama-server-service.ollama-dist.svc.cluster.local:11434'
       name: llama-stack
     distribution:
-      name: ollama
+      name: starter
     # Uncomment the storage section to use persistent storage
     # storage: {}  # Will use default size of 10Gi and default mount path of /.llama
     # Or specify custom values:

--- a/config/samples/example-with-ca-bundle.yaml
+++ b/config/samples/example-with-ca-bundle.yaml
@@ -6,7 +6,7 @@ data:
   run.yaml: |
     # Llama Stack Configuration
     version: '2'
-    image_name: remote-vllm
+    image_name: starter
     apis:
     - inference
     providers:
@@ -30,7 +30,7 @@ spec:
   replicas: 1
   server:
     distribution:
-      name: remote-vllm
+      name: starter
     containerSpec:
       port: 8321
       env:

--- a/config/samples/example-with-configmap.yaml
+++ b/config/samples/example-with-configmap.yaml
@@ -6,7 +6,7 @@ data:
   run.yaml: |
     # Llama Stack Configuration
     version: '2'
-    image_name: ollama
+    image_name: starter
     apis:
     - inference
     providers:
@@ -30,7 +30,7 @@ spec:
   replicas: 1
   server:
     distribution:
-      name: ollama
+      name: starter
     containerSpec:
       port: 8321
       env:

--- a/tests/e2e/deletion_test.go
+++ b/tests/e2e/deletion_test.go
@@ -7,24 +7,15 @@ import (
 	"github.com/llamastack/llama-stack-k8s-operator/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestDeletionSuite(t *testing.T) {
-	if TestOpts.SkipDeletion {
-		t.Skip("Skipping deletion test suite")
-	}
+// runDeletionTests runs deletion tests for a specific distribution
+func runDeletionTests(t *testing.T, instance *v1alpha1.LlamaStackDistribution) {
+	t.Helper()
 
 	t.Run("should delete LlamaStackDistribution CR and cleanup resources", func(t *testing.T) {
-		instance := &v1alpha1.LlamaStackDistribution{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "llamastackdistribution-sample",
-				Namespace: "llama-stack-test",
-			},
-		}
-
 		// Delete the instance
 		err := TestEnv.Client.Delete(TestEnv.Ctx, instance)
 		require.NoError(t, err)

--- a/tests/e2e/deletion_test.go
+++ b/tests/e2e/deletion_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// runDeletionTests runs deletion tests for a specific distribution
+// runDeletionTests runs deletion tests for a specific distribution.
 func runDeletionTests(t *testing.T, instance *v1alpha1.LlamaStackDistribution) {
 	t.Helper()
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -3,6 +3,9 @@ package e2e
 
 import (
 	"testing"
+
+	"github.com/llamastack/llama-stack-k8s-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestE2E(t *testing.T) {
@@ -10,24 +13,47 @@ func TestE2E(t *testing.T) {
 	// Run validation tests
 	t.Run("validation", TestValidationSuite)
 
-	// Track if creation tests passed
-	creationFailed := false
-
-	// Run creation tests
-	t.Run("creation", func(t *testing.T) {
-		TestCreationSuite(t)
-		creationFailed = t.Failed()
-	})
+	// Run combined creation and deletion tests
+	t.Run("creation-deletion", TestCreationDeletionSuite)
 
 	// Run TLS tests
 	t.Run("tls", func(t *testing.T) {
 		TestTLSSuite(t)
 	})
+}
+
+// TestCreationDeletionSuite runs creation tests followed by deletion tests
+// This allows for complete lifecycle testing with different distribution images
+func TestCreationDeletionSuite(t *testing.T) {
+	if TestOpts.SkipCreation {
+		t.Skip("Skipping creation-deletion test suite")
+	}
+
+	var creationFailed bool
+
+	// Run all creation tests
+	t.Run("creation", func(t *testing.T) {
+		TestCreationSuite(t)
+		creationFailed = t.Failed()
+	})
 
 	// Run deletion tests only if creation passed
-	if !creationFailed {
-		t.Run("deletion", TestDeletionSuite)
+	if !creationFailed && !TestOpts.SkipDeletion {
+		t.Run("deletion", func(t *testing.T) {
+			// Create distribution instance for deletion
+			instance := &v1alpha1.LlamaStackDistribution{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "llamastackdistribution-sample",
+					Namespace: "llama-stack-test",
+				},
+			}
+			runDeletionTests(t, instance)
+		})
 	} else {
-		t.Log("Skipping deletion tests due to creation test failures")
+		if TestOpts.SkipDeletion {
+			t.Log("Skipping deletion tests (SkipDeletion=true)")
+		} else {
+			t.Log("Skipping deletion tests due to creation test failures")
+		}
 	}
 }

--- a/tests/e2e/test_utils.go
+++ b/tests/e2e/test_utils.go
@@ -28,6 +28,7 @@ import (
 )
 
 const (
+	starterDistType      = "starter"
 	ollamaNS             = "ollama-dist"
 	pollInterval         = 10 * time.Second
 	ResourceReadyTimeout = 5 * time.Minute
@@ -162,8 +163,8 @@ func registerSchemes() {
 	}
 }
 
-// GetSampleCR returns a LlamaStackDistribution from the sample YAML file.
-func GetSampleCR(t *testing.T) *v1alpha1.LlamaStackDistribution {
+// GetSampleCRForDistribution returns a LlamaStackDistribution configured for the specified distribution type.
+func GetSampleCRForDistribution(t *testing.T, distType string) *v1alpha1.LlamaStackDistribution {
 	t.Helper()
 	// Get the absolute path of the project root
 	projectRoot, err := filepath.Abs("../..")
@@ -180,6 +181,15 @@ func GetSampleCR(t *testing.T) *v1alpha1.LlamaStackDistribution {
 	distribution := &v1alpha1.LlamaStackDistribution{}
 	err = yaml.Unmarshal(yamlFile, distribution)
 	require.NoError(t, err)
+
+	// Modify the distribution based on the type
+	switch distType {
+	case starterDistType:
+		distribution.Spec.Server.Distribution.Name = starterDistType
+		distribution.ObjectMeta.Name = "llamastackdistribution-" + starterDistType + "-sample"
+	default:
+		t.Fatalf("Unknown distribution type: %s", distType)
+	}
 
 	return distribution
 }


### PR DESCRIPTION
    test: remove ollama distribution testing, replace with starter
    
    This focuses testing on the actively maintained starter distribution
    while removing support for the older ollama image that's no longer updated.
    
    Also intrduces a list of distro images (currently only 1) that can be tested.
    
---
    test: combine creation and deletion into single lifecycle test
    
    Restructure the creation test to run creation followed by deletion in a single
    test suite. This enables testing multiple distribution images sequentially
    with proper cleanup between runs.
    
    Changes:
    - Add TestCreationDeletionSuite that runs creation then deletion
    - Replace TestDeletionSuite with runDeletionTests helper function
    - Simplify test structure while maintaining all existing functionality
