### PR TITLE
Add Service Endpoint to LlamaStackDistribution .status

### DIFF
--- a/api/v1alpha1/llamastackdistribution_types.go
+++ b/api/v1alpha1/llamastackdistribution_types.go
@@ -205,6 +205,8 @@ type LlamaStackDistributionStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// AvailableReplicas is the number of available replicas
 	AvailableReplicas int32 `json:"availableReplicas,omitempty"`
+	// ServiceURL is the internal Kubernetes service URL where the distribution is exposed
+	ServiceURL string `json:"serviceURL,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/llamastack.io_llamastackdistributions.yaml
+++ b/config/crd/bases/llamastack.io_llamastackdistributions.yaml
@@ -2174,6 +2174,10 @@ spec:
                 - Failed
                 - Terminating
                 type: string
+              serviceURL:
+                description: ServiceURL is the internal Kubernetes service URL where
+                  the distribution is exposed
+                type: string
               version:
                 description: Version contains version information for both operator
                   and deployment

--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -1030,6 +1030,11 @@ func (r *LlamaStackDistributionReconciler) updateServiceStatus(ctx context.Conte
 		SetServiceReadyCondition(&instance.Status, false, fmt.Sprintf("Failed to get Service: %v", err))
 		return
 	}
+
+	// Set the service URL in the status
+	serviceURL := r.getServerURL(instance, "")
+	instance.Status.ServiceURL = serviceURL.String()
+
 	SetServiceReadyCondition(&instance.Status, true, MessageServiceReady)
 }
 

--- a/controllers/llamastackdistribution_controller_test.go
+++ b/controllers/llamastackdistribution_controller_test.go
@@ -452,6 +452,12 @@ func TestLlamaStackProviderAndVersionInfo(t *testing.T) {
 	require.Equal(t, expectedLlamaStackVersionInfo,
 		updatedInstance.Status.Version.LlamaStackServerVersion,
 		"server version should match the mock response")
+
+	// validate service URL
+	expectedServiceURL := fmt.Sprintf("http://%s-service.%s.svc.cluster.local:%d",
+		instance.Name, instance.Namespace, llamav1alpha1.DefaultServerPort)
+	require.Equal(t, expectedServiceURL, updatedInstance.Status.ServiceURL,
+		"service URL should be set to the internal Kubernetes service URL")
 }
 
 func TestNetworkPolicyConfiguration(t *testing.T) {

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -139,6 +139,7 @@ _Appears in:_
 | `distributionConfig` _[DistributionConfig](#distributionconfig)_ | DistributionConfig contains the configuration information from the providers endpoint |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#condition-v1-meta) array_ | Conditions represent the latest available observations of the distribution's current state |  |  |
 | `availableReplicas` _integer_ | AvailableReplicas is the number of available replicas |  |  |
+| `serviceURL` _string_ | ServiceURL is the internal Kubernetes service URL where the distribution is exposed |  |  |
 
 #### PodOverrides
 

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -2183,6 +2183,10 @@ spec:
                 - Failed
                 - Terminating
                 type: string
+              serviceURL:
+                description: ServiceURL is the internal Kubernetes service URL where
+                  the distribution is exposed
+                type: string
               version:
                 description: Version contains version information for both operator
                   and deployment


### PR DESCRIPTION
## Description

The `.status.serviceURL` field in the `LlamaStackDistribution` resource would now have the value i.e.,:
```
http://<service-name>.<namespace>.svc.cluster.local:<port>
```

Note: the pre-commit linter seems to not like the use of `serviceUrl`. It said to use `serviceURL` instead.

## Verification Steps
I tested the service by:
1. Running my own version of llama-stack-k8s-operator on OpenShift with the changes in this PR: `make deploy IMG=quay.io/rh_ee_czaccari/llama-stack-k8s-operator:servicestatus4`
2. Created a sample LlamaStackDistribution.
3. Then I ran a test pod:

>kubectl run curl-test --image=quay.io/rh_ee_czaccari/curl:test5 --rm -it --restart=Never -n ollama-dist -- curl -k -v http://llamastackdistribution-sample-service.ollama-dist.svc.cluster.local:8321/v1/models
