### PR TITLE
chore: remove review-requested=0 condition to prevent auto-merge blocking

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,7 +4,6 @@ pull_request_rules:
     Automatic merge of PRs to main
   conditions:
     - "#approved-reviews-by>=1"
-    - "#review-requested=0"
     - "#changes-requested-reviews-by=0"
     - base=main
     - label!=do-not-merge


### PR DESCRIPTION
Allows Mergify to auto-merge PRs even when there are pending review requests, as long as the minimum approval threshold is met and no changes are requested.

This prevents situations where PRs with sufficient approvals get blocked because some requested reviewers haven't responded yet.