### PR TITLE
feat: add fips-compliant annotation to CSV

### DIFF
--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -7,3 +7,10 @@ resources:
 - ../default
 - ../samples
 - ../scorecard
+
+patches:
+- path: patches/fips-annotation-patch.yaml
+  target:
+    group: operators.coreos.com
+    version: v1alpha1
+    kind: ClusterServiceVersion

--- a/config/manifests/patches/fips-annotation-patch.yaml
+++ b/config/manifests/patches/fips-annotation-patch.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    features.operators.openshift.io/fips-compliant: "true"


### PR DESCRIPTION
Adding `features.operators.openshift.io/fips-compliant: "true"` annotation to the CSV as per the FIPS Operator checklist.

Closes RHAIENG-1325.