### PR TITLE
fix: updating example files with required storage config

### DIFF
--- a/config/samples/example-with-ca-bundle.yaml
+++ b/config/samples/example-with-ca-bundle.yaml
@@ -21,6 +21,29 @@ data:
         model_type: llm
     server:
       port: 8321
+    storage:
+      backends:
+        kv_default:
+          type: kv_sqlite
+          db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/ollama}/kvstore.db
+        sql_default:
+          type: sql_sqlite
+          db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/ollama}/sqlstore.db
+      stores:
+        metadata:
+          backend: kv_default
+          namespace: registry
+        inference:
+          backend: sql_default
+          table_name: inference_store
+          max_write_queue_size: 10000
+          num_writers: 4
+        conversations:
+          backend: sql_default
+          table_name: openai_conversations
+        prompts:
+          backend: kv_default
+          namespace: prompts
 ---
 apiVersion: llamastack.io/v1alpha1
 kind: LlamaStackDistribution

--- a/config/samples/example-with-configmap.yaml
+++ b/config/samples/example-with-configmap.yaml
@@ -21,6 +21,29 @@ data:
         model_type: llm
     server:
       port: 8321
+    storage:
+      backends:
+        kv_default:
+          type: kv_sqlite
+          db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/ollama}/kvstore.db
+        sql_default:
+          type: sql_sqlite
+          db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/ollama}/sqlstore.db
+      stores:
+        metadata:
+          backend: kv_default
+          namespace: registry
+        inference:
+          backend: sql_default
+          table_name: inference_store
+          max_write_queue_size: 10000
+          num_writers: 4
+        conversations:
+          backend: sql_default
+          table_name: openai_conversations
+        prompts:
+          backend: kv_default
+          namespace: prompts
 ---
 apiVersion: llamastack.io/v1alpha1
 kind: LlamaStackDistribution


### PR DESCRIPTION
Updating the example files with the latest requirements from https://github.com/llamastack/llama-stack/blob/main/docs/docs/distributions/configuration.mdx. to prevent crashing on server start. The e2e tests pass again now that the upstream distribution `external_providers_dir` fix has made it into the latest `docker.io/llamastack/distribution-starter:latest` image.

The `storage` parameters match documentation, and what's already in `/usr/local/lib/python3.12/site-packages/llama_stack/distributions/starter/run.yaml`

Closes: RHAIENG-1655