### PR TITLE
chore: add dependabot to automate dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+
+    groups:
+      k8s-dependencies:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
Adds dependabot configuration to keep dependencies current. Current controller-runtime (v0.17.2) and k8s.io dependencies (v0.29.x) are behind upstream releases (controller-runtime v0.22.4, Kubernetes v1.34.1).

Dependabot will create daily PRs for Go modules and GitHub Actions, and weekly PRs for Docker base images. Kubernetes dependencies are grouped to reduce PR noise.

Example of PRs created by dependabot in operator-framework repositories: [PRs](https://github.com/operator-framework/operator-controller/pulls?q=dependabot+assignee%3Aanik120)

See [dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot) for more info.

Signed-off-by: Anik Bhattacharjee <anbhatta@redhat.com>