### PR TITLE
chore: exclude vendor directory from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: "build/"
+exclude: "build/|vendor/"
 
 default_language_version:
   python: python3


### PR DESCRIPTION
Exclude the vendor/ directory from pre-commit hook execution to avoid unnecessary checks on third-party dependencies.

These files cannot be edited (will violate `go mod`).