### PR TITLE
feat(ci): add e2e test validation to release workflow

### DIFF
--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -21,12 +21,20 @@ env:
   GIT_USER_EMAIL: github-actions[bot]@users.noreply.github.com
 
 jobs:
+  test-e2e:
+    uses: ./.github/workflows/run-e2e-test.yml
+
   generate-release:
     runs-on: ubuntu-24.04
+    needs: test-e2e
+    if: always()
     outputs:
       operator_version: ${{ steps.validate.outputs.operator_version }}
       llamastack_version: ${{ steps.validate.outputs.llamastack_version }}
       release_branch: ${{ steps.validate.outputs.release_branch }}
+      e2e_success: ${{ needs.test-e2e.outputs.success }}
+      e2e_summary: ${{ needs.test-e2e.outputs.summary }}
+      e2e_run_url: ${{ needs.test-e2e.outputs.run_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
@@ -156,6 +164,21 @@ jobs:
         shell: bash
         run: |
           make test
+
+      - name: Check E2E Test Results
+        run: |
+          echo "E2E Test Results:"
+          echo "Success: ${{ needs.test-e2e.outputs.success }}"
+          echo "Summary: ${{ needs.test-e2e.outputs.summary }}"
+          echo "Run URL: ${{ needs.test-e2e.outputs.run_url }}"
+
+          if [ "${{ needs.test-e2e.outputs.success }}" != "true" ]; then
+            echo "E2E tests failed - release cannot proceed"
+            echo "Check detailed logs: ${{ needs.test-e2e.outputs.run_url }}"
+            exit 1
+          else
+            echo "E2E tests passed - proceeding with release"
+          fi
 
       - name: Validate build release image
         shell: bash


### PR DESCRIPTION
Add test-e2e job that calls run-e2e-test.yml before building release 
artifacts. Release fails if e2e tests fail.