### PR TITLE
feat: Add support for uvicorn workers for llama-stack

### DIFF
--- a/api/v1alpha1/llamastackdistribution_types.go
+++ b/api/v1alpha1/llamastackdistribution_types.go
@@ -81,7 +81,14 @@ type LlamaStackDistributionSpec struct {
 type ServerSpec struct {
 	Distribution  DistributionType `json:"distribution"`
 	ContainerSpec ContainerSpec    `json:"containerSpec,omitempty"`
-	PodOverrides  *PodOverrides    `json:"podOverrides,omitempty"` // Optional pod-level overrides
+	// Workers configures the number of uvicorn worker processes to run.
+	// When set, the operator will launch llama-stack using uvicorn with the specified worker count.
+	// Ref: https://fastapi.tiangolo.com/deployment/server-workers/
+	// CPU requests are set to the number of workers when set, otherwise 1 full core
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	Workers      *int32        `json:"workers,omitempty"`
+	PodOverrides *PodOverrides `json:"podOverrides,omitempty"` // Optional pod-level overrides
 	// PodDisruptionBudget controls voluntary disruption tolerance for the server pods
 	// +optional
 	PodDisruptionBudget *PodDisruptionBudgetSpec `json:"podDisruptionBudget,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -344,6 +344,11 @@ func (in *ServerSpec) DeepCopyInto(out *ServerSpec) {
 	*out = *in
 	out.Distribution = in.Distribution
 	in.ContainerSpec.DeepCopyInto(&out.ContainerSpec)
+	if in.Workers != nil {
+		in, out := &in.Workers, &out.Workers
+		*out = new(int32)
+		**out = **in
+	}
 	if in.PodOverrides != nil {
 		in, out := &in.PodOverrides, &out.PodOverrides
 		*out = new(PodOverrides)

--- a/config/crd/bases/llamastack.io_llamastackdistributions.yaml
+++ b/config/crd/bases/llamastack.io_llamastackdistributions.yaml
@@ -2568,6 +2568,15 @@ spec:
                     required:
                     - configMapName
                     type: object
+                  workers:
+                    description: |-
+                      Workers configures the number of uvicorn worker processes to run.
+                      When set, the operator will launch llama-stack using uvicorn with the specified worker count.
+                      Ref: https://fastapi.tiangolo.com/deployment/server-workers/
+                      CPU requests are set to the number of workers when set, otherwise 1 full core
+                    format: int32
+                    minimum: 1
+                    type: integer
                 required:
                 - distribution
                 type: object

--- a/config/samples/_v1alpha1_llamastackdistribution.yaml
+++ b/config/samples/_v1alpha1_llamastackdistribution.yaml
@@ -14,6 +14,7 @@ spec:
       name: llama-stack
     distribution:
       name: starter
+    workers: 2
     podDisruptionBudget:
       minAvailable: 1
     topologySpreadConstraints:

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -218,6 +218,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `distribution` _[DistributionType](#distributiontype)_ |  |  |  |
 | `containerSpec` _[ContainerSpec](#containerspec)_ |  |  |  |
+| `workers` _integer_ | Workers configures the number of uvicorn worker processes to run.<br />When set, the operator will launch llama-stack using uvicorn with the specified worker count.<br />Ref: https://fastapi.tiangolo.com/deployment/server-workers/<br />CPU requests are set to the number of workers when set, otherwise 1 full core |  | Minimum: 1 <br /> |
 | `podOverrides` _[PodOverrides](#podoverrides)_ |  |  |  |
 | `podDisruptionBudget` _[PodDisruptionBudgetSpec](#poddisruptionbudgetspec)_ | PodDisruptionBudget controls voluntary disruption tolerance for the server pods |  |  |
 | `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#topologyspreadconstraint-v1-core) array_ | TopologySpreadConstraints defines fine-grained spreading rules |  |  |

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -2577,6 +2577,15 @@ spec:
                     required:
                     - configMapName
                     type: object
+                  workers:
+                    description: |-
+                      Workers configures the number of uvicorn worker processes to run.
+                      When set, the operator will launch llama-stack using uvicorn with the specified worker count.
+                      Ref: https://fastapi.tiangolo.com/deployment/server-workers/
+                      CPU requests are set to the number of workers when set, otherwise 1 full core
+                    format: int32
+                    minimum: 1
+                    type: integer
                 required:
                 - distribution
                 type: object


### PR DESCRIPTION
Fixes #164 
Expose `worker` field in `LlamaStackDistribution` CR

Example CR
```
spec:
  server:
    containerSpec:
      env:
        - name: OLLAMA_INFERENCE_MODEL
          value: 'llama3.2:1b'
        - name: OLLAMA_URL
          value: 'http://ollama-server-service.ollama-dist.svc.cluster.local:11434'
      name: llama-stack
    distribution:
      name: starter
    workers: 2
```