### PR TITLE
build(golang): update Go to 1.25 for CVE-2025-61729

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - name: Set up Go 1.24
+      - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -20,7 +20,7 @@ jobs:
   build-release-image:
     runs-on: ubuntu-24.04
     steps:
-      - name: Set up Go 1.24
+      - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version-file: go.mod

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GOLANG_VERSION=1.24
+ARG GOLANG_VERSION=1.25
 
 # Use BUILDPLATFORM to run the builder natively (avoid QEMU emulation for Go compilation)
 # This dramatically improves build reliability and speed for cross-platform builds

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests. Use TEST_PKGS and TEST_FLAGS to customize.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(TEST_PKGS) $(TEST_FLAGS)
+	GOTOOLCHAIN=go1.25.5+auto KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(TEST_PKGS) $(TEST_FLAGS)
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/llamastack/llama-stack-k8s-operator
 
-go 1.24.6
+go 1.25.5
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary

Update Go from 1.24 to 1.25 to address CVE-2025-61729, a denial-of-service vulnerability in `crypto/x509.HostnameError.Error()`.

## Vulnerability Details

- **CVE**: CVE-2025-61729
- **Affected**: crypto/x509 in Go < 1.24.11 and 1.25.0-1.25.4
- **Impact**: Certificates with excessive hostnames cause quadratic runtime during error string construction
- **Patched in**: Go 1.25.5 and 1.24.11

The operator is potentially affected through Kubernetes client-go dependencies which perform TLS hostname verification.

**Reference**: https://pkg.go.dev/vuln/GO-2025-4155