### PR TITLE
feat: add default env var for kube auth

### DIFF
--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -300,7 +300,16 @@ func configureContainerEnvironment(ctx context.Context, r *LlamaStackDistributio
 		},
 	)
 
-	// Finally, add the user provided env vars
+	// Add OpenShift/Kubernetes API server URL for RBAC authentication.
+	// This enables the Kubernetes auth provider in llama-stack to validate tokens
+	// against the API server for access control.
+	// Default to in-cluster service URL; can be overridden via user-provided env vars.
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name:  "OPENSHIFT_SERVER_API_URL",
+		Value: "https://kubernetes.default.svc",
+	})
+
+	// Finally, add the user provided env vars (these take precedence over defaults)
 	container.Env = append(container.Env, instance.Spec.Server.ContainerSpec.Env...)
 }
 

--- a/controllers/resource_helper_test.go
+++ b/controllers/resource_helper_test.go
@@ -73,6 +73,7 @@ func TestBuildContainerSpec(t *testing.T) {
 					{Name: "LLS_WORKERS", Value: "1"},
 					{Name: "LLS_PORT", Value: "8321"},
 					{Name: "LLAMA_STACK_CONFIG", Value: "/etc/llama-stack/config.yaml"},
+					{Name: "OPENSHIFT_SERVER_API_URL", Value: "https://kubernetes.default.svc"},
 				},
 			},
 		},
@@ -121,6 +122,7 @@ func TestBuildContainerSpec(t *testing.T) {
 					{Name: "LLS_WORKERS", Value: "1"},
 					{Name: "LLS_PORT", Value: "9000"},
 					{Name: "LLAMA_STACK_CONFIG", Value: "/etc/llama-stack/config.yaml"},
+					{Name: "OPENSHIFT_SERVER_API_URL", Value: "https://kubernetes.default.svc"},
 					{Name: "TEST_ENV", Value: "test-value"},
 				},
 				VolumeMounts: []corev1.VolumeMount{{
@@ -165,6 +167,7 @@ func TestBuildContainerSpec(t *testing.T) {
 					{Name: "LLS_WORKERS", Value: "1"},
 					{Name: "LLS_PORT", Value: "8321"},
 					{Name: "LLAMA_STACK_CONFIG", Value: "/etc/llama-stack/config.yaml"},
+					{Name: "OPENSHIFT_SERVER_API_URL", Value: "https://kubernetes.default.svc"},
 				},
 			},
 		},
@@ -198,6 +201,7 @@ func TestBuildContainerSpec(t *testing.T) {
 					{Name: "LLS_WORKERS", Value: "4"},
 					{Name: "LLS_PORT", Value: "8321"},
 					{Name: "LLAMA_STACK_CONFIG", Value: "/etc/llama-stack/config.yaml"},
+					{Name: "OPENSHIFT_SERVER_API_URL", Value: "https://kubernetes.default.svc"},
 				},
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      "lls-storage",
@@ -240,6 +244,7 @@ func TestBuildContainerSpec(t *testing.T) {
 					{Name: "LLS_WORKERS", Value: "1"},
 					{Name: "LLS_PORT", Value: "8321"},
 					{Name: "LLAMA_STACK_CONFIG", Value: "/etc/llama-stack/config.yaml"},
+					{Name: "OPENSHIFT_SERVER_API_URL", Value: "https://kubernetes.default.svc"},
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{


### PR DESCRIPTION
Adding `OPENSHIFT_SERVER_API_URL` as a default LlamaStackDistribution env var, so it doesn't need to be specified manually in the CR. This allows llama-stack servers to validate user tokens against the OpenShift API server for Kubernetes-based RBAC authentication.

The change supports the crimson dashboard feature request at https://issues.redhat.com/browse/RHOAIENG-34370.