### PR TITLE
fix: Bump go version to 1.25.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ARG TARGETPLATFORM
 # For native builds: CGO_ENABLED=1 with full FIPS OpenSSL support
 # For cross-builds: CGO_ENABLED=0 with pure Go FIPS (strictfipsruntime)
 ENV GOEXPERIMENT=strictfipsruntime
+ENV GOTOOLCHAIN=auto
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests. Use TEST_PKGS and TEST_FLAGS to customize.
-	GOTOOLCHAIN=go1.25.5+auto KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(TEST_PKGS) $(TEST_FLAGS)
+	GOTOOLCHAIN=go1.25.8+auto KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(TEST_PKGS) $(TEST_FLAGS)
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/llamastack/llama-stack-k8s-operator
 
-go 1.25.5
+go 1.25.8
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Fixes CVE-2025-61726