### PR TITLE
fix(ci): configure insecure registry for Docker 29 compatibility

### DIFF
--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -82,6 +82,9 @@ jobs:
 
       - name: Push operator image to local registry
         run: |
+          echo '{"insecure-registries": ["kind-registry:5000"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          until docker exec kind-registry true 2>/dev/null; do sleep 1; done
           docker push kind-registry:5000/llama-stack-k8s-operator:latest
 
       - name: Deploy operator


### PR DESCRIPTION
Docker 29 defaults to the containerd image store which no longer falls back from HTTPS to HTTP when pushing to registries. This broke the e2e test push to the local Kind registry at kind-registry:5000.