### PR TITLE
chore: Sync linting error

### DIFF
--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -633,7 +633,7 @@ func TestRemoveDeploymentReplicas(t *testing.T) {
 
 // TestHasLegacyCABundleVolumes tests the detection of legacy CA bundle volumes.
 func TestHasLegacyCABundleVolumes(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("detects legacy emptyDir ca-bundle volume", func(t *testing.T) {
 		deployment := newTestResource(t, "apps/v1", "Deployment", "test-deploy", "test-ns", map[string]any{


### PR DESCRIPTION
Downstream linter had a problem with this line, changing upstream to avoid future merge conflicts.

---
linting failed on this downstream cherry-pick  https://github.com/red-hat-data-services/llama-stack-k8s-operator/pull/183