### PR TITLE
ci: setup ARM64 builds with CGO_ENABLED=1 compatibility

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -8,10 +8,23 @@ permissions:
   actions: write
   contents: read
 
+env:
+  IMG: quay.io/llamastack/llama-stack-k8s-operator:latest
+
 jobs:
-  build-latest-image:
+  build-arch:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,5 +44,30 @@ jobs:
           username: ${{ secrets.APP_QUAY_USERNAME }}
           password: ${{ secrets.APP_QUAY_TOKEN }}
 
-      - name: Build and push multi-arch image
-        run: make image-buildx -e IMG=quay.io/llamastack/llama-stack-k8s-operator:latest
+      - name: Build and push single-arch image
+        run: |
+          make image-build-push-single \
+            CONTAINER_TOOL=docker \
+            PLATFORM=${{ matrix.platform }} \
+            IMG=${{ env.IMG }}-${{ matrix.arch }}
+
+  create-manifest:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    needs: build-arch
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Login to Quay.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.APP_QUAY_USERNAME }}
+          password: ${{ secrets.APP_QUAY_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ${{ env.IMG }} \
+            ${{ env.IMG }}-amd64 \
+            ${{ env.IMG }}-arm64

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -165,9 +165,6 @@ jobs:
         run: |
           make test
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
-
       - name: Check E2E Test Results
         run: |
           echo "E2E Test Results:"
@@ -183,10 +180,10 @@ jobs:
             echo "E2E tests passed - proceeding with release"
           fi
 
-      - name: Validate build release image
+      - name: Validate release image build
         shell: bash
         run: |
-          make image-buildx-build IMG=quay.io/llamastack/llama-stack-k8s-operator:v${{ steps.validate.outputs.operator_version }}
+          make image-build IMG=quay.io/llamastack/llama-stack-k8s-operator:v${{ steps.validate.outputs.operator_version }}
 
       - name: Commit and push changes
         shell: bash
@@ -203,13 +200,58 @@ jobs:
             echo "✅ Committed release changes to ${{ steps.validate.outputs.release_branch }}"
           fi
 
-  finalize-release:
+  build-release-arch:
     needs: generate-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    env:
+      operator_version: ${{ needs.generate-release.outputs.operator_version }}
+      release_branch: ${{ needs.generate-release.outputs.release_branch }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ env.release_branch }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.APP_QUAY_USERNAME }}
+          password: ${{ secrets.APP_QUAY_TOKEN }}
+
+      - name: Build and push single-arch release image
+        run: |
+          make image-build-push-single \
+            CONTAINER_TOOL=docker \
+            PLATFORM=${{ matrix.platform }} \
+            IMG=quay.io/llamastack/llama-stack-k8s-operator:v${{ env.operator_version }}-${{ matrix.arch }}
+
+  finalize-release:
+    needs: [generate-release, build-release-arch]
     runs-on: ubuntu-24.04
     env:
       operator_version: ${{ needs.generate-release.outputs.operator_version }}
       llamastack_version: ${{ needs.generate-release.outputs.llamastack_version }}
       release_branch: ${{ needs.generate-release.outputs.release_branch }}
+      IMG: quay.io/llamastack/llama-stack-k8s-operator
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -268,11 +310,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version-file: go.mod
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
@@ -283,17 +320,20 @@ jobs:
           username: ${{ secrets.APP_QUAY_USERNAME }}
           password: ${{ secrets.APP_QUAY_TOKEN }}
 
-      - name: Build and push multi-arch release image
+      - name: Create and push multi-arch manifest
         shell: bash
         run: |
-          make image-buildx IMG=quay.io/llamastack/llama-stack-k8s-operator:v${{ env.operator_version }}
-          echo "✅ Pushed multi-arch image: quay.io/llamastack/llama-stack-k8s-operator:v${{ env.operator_version }}"
+          docker buildx imagetools create \
+            -t ${{ env.IMG }}:v${{ env.operator_version }} \
+            ${{ env.IMG }}:v${{ env.operator_version }}-amd64 \
+            ${{ env.IMG }}:v${{ env.operator_version }}-arm64
+          echo "✅ Pushed multi-arch image: ${{ env.IMG }}:v${{ env.operator_version }}"
 
       - name: Release complete
         shell: bash
         run: |
           echo "🚀 Release v${{ env.operator_version }} completed successfully!"
-          echo "📦 Container image: quay.io/llamastack/llama-stack-k8s-operator:v${{ env.operator_version }}"
+          echo "📦 Container image: ${{ env.IMG }}:v${{ env.operator_version }}"
           echo "📝 Release notes: https://github.com/${{ github.repository }}/releases/tag/v${{ env.operator_version }}"
           echo "🔧 Install with: kubectl apply -f https://raw.githubusercontent.com/llamastack/llama-stack-k8s-operator/v${{ env.operator_version }}/release/operator.yaml"
           echo "🌿 Release branch: ${{ env.release_branch }}"

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -16,9 +16,22 @@ permissions:
   actions: write
   contents: read
 
+env:
+  IMG: quay.io/llamastack/llama-stack-k8s-operator:${{ github.event.inputs.version }}
+
 jobs:
-  build-release-image:
-    runs-on: ubuntu-24.04
+  build-arch:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -40,6 +53,29 @@ jobs:
           username: ${{ secrets.APP_QUAY_USERNAME }}
           password: ${{ secrets.APP_QUAY_TOKEN }}
 
-      - name: Build and push multi-arch release image
+      - name: Build and push single-arch release image
         run: |
-          make image-buildx -e IMG=quay.io/llamastack/llama-stack-k8s-operator:${{ github.event.inputs.version }}
+          make image-build-push-single \
+            CONTAINER_TOOL=docker \
+            PLATFORM=${{ matrix.platform }} \
+            IMG=${{ env.IMG }}-${{ matrix.arch }}
+
+  create-manifest:
+    needs: build-arch
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Login to Quay.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.APP_QUAY_USERNAME }}
+          password: ${{ secrets.APP_QUAY_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ${{ env.IMG }} \
+            ${{ env.IMG }}-amd64 \
+            ${{ env.IMG }}-arm64


### PR DESCRIPTION
Switching to a matrix strategy so that ARM64 builds are done natively on ARM architecture github runners. This allows ARM64 multi-arch compatibility while still relying on the host's FIPS-compliant openssl library.

Previously, attempts to use CGO_ENABLED=1 with a non-ARM64 architecture build host resulted in builds freezing with no error output.

Closes: RHAIENG-2913