### PR TITLE
docs: document ENABLE_INLINE_MILVUS limitations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ spec:
 ```
 3. Verify the server pod is running in the user defined namespace.
 
+### Local Vector Storage (inline::milvus)
+
+To enable the `inline::milvus` local vector storage provider, set `ENABLE_INLINE_MILVUS` in `spec.server.containerSpec.env`. This is only supported in single-worker, single-replica deployments. Milvus-Lite uses SQLite internally and does not support concurrent access from multiple processes.
+
 ### Using a ConfigMap for config.yaml configuration
 
 A ConfigMap can be used to store config.yaml configuration for each LlamaStackDistribution.


### PR DESCRIPTION
[RHAIENG-3916](https://issues.redhat.com/browse/RHAIENG-3916)

### Description

Companion to opendatahub-io/llama-stack-distribution#318.

Documents that `inline::milvus` (enabled via `ENABLE_INLINE_MILVUS`)
is only supported in single-worker, single-replica deployments. The
operator does not manage or validate this env var.

### How Has This Been Tested?

```bash
make test
```

### Test Impact

None. Documentation only.