### PR TITLE
fix: Reset feature flags to default on upgrade

### DIFF
--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -1541,17 +1541,7 @@ func initializeOperatorConfigMap(ctx context.Context, c client.Client, operatorN
 
 	err := c.Get(ctx, configMapName, configMap)
 	if err == nil {
-		// Ensure the watch label exists (upgrade path)
-		if configMap.Labels == nil || configMap.Labels[WatchLabelKey] != WatchLabelValue {
-			if configMap.Labels == nil {
-				configMap.Labels = make(map[string]string)
-			}
-			configMap.Labels[WatchLabelKey] = WatchLabelValue
-			if updateErr := c.Update(ctx, configMap); updateErr != nil {
-				return nil, fmt.Errorf("failed to add watch label to operator config ConfigMap: %w", updateErr)
-			}
-		}
-		return configMap, nil
+		return upgradeOperatorConfigMap(ctx, c, configMap, configMapName)
 	}
 
 	if !k8serrors.IsNotFound(err) {
@@ -1569,6 +1559,110 @@ func initializeOperatorConfigMap(ctx context.Context, c client.Client, operatorN
 	}
 
 	return configMap, nil
+}
+
+// upgradeOperatorConfigMap ensures an existing operator ConfigMap has the watch
+// label and all known feature flags. When ResetOnUpgrade is true (midstream)
+// all flags are reset to defaults on version change; otherwise only missing
+// flags are filled in.
+func upgradeOperatorConfigMap(ctx context.Context, c client.Client, configMap *corev1.ConfigMap, configMapName types.NamespacedName) (*corev1.ConfigMap, error) {
+	needsUpdate := false
+	patch := client.MergeFrom(configMap.DeepCopy())
+
+	// Ensure the watch label exists (upgrade path)
+	if configMap.Labels == nil {
+		configMap.Labels = make(map[string]string)
+	}
+	if configMap.Labels[WatchLabelKey] != WatchLabelValue {
+		configMap.Labels[WatchLabelKey] = WatchLabelValue
+		needsUpdate = true
+	}
+
+	if configMap.Data == nil {
+		configMap.Data = make(map[string]string)
+	}
+
+	// Reset all flags to defaults on version change for midstream.
+	if featureflags.ResetOnUpgrade && needsConfigMapUpdate(ctx, c) {
+		newConfigMap, genErr := createDefaultConfigMap(configMapName)
+		if genErr != nil {
+			return nil, fmt.Errorf("failed to generate default configMap: %w", genErr)
+		}
+		configMap.Data[featureflags.FeatureFlagsKey] = newConfigMap.Data[featureflags.FeatureFlagsKey]
+		needsUpdate = true
+	}
+
+	// Always ensure missing flags have defaults (e.g., new flags in upgrades).
+	if updatedFlags, changed := ensureDefaultFeatureFlags(configMap.Data); changed {
+		configMap.Data[featureflags.FeatureFlagsKey] = updatedFlags
+		needsUpdate = true
+	}
+
+	if needsUpdate {
+		if patchErr := c.Patch(ctx, configMap, patch); patchErr != nil {
+			return nil, fmt.Errorf("failed to patch ConfigMap: %w", patchErr)
+		}
+	}
+
+	return configMap, nil
+}
+
+// needsConfigMapUpdate checks if the ConfigMap needs to be updated with new defaults.
+func needsConfigMapUpdate(ctx context.Context, c client.Client) bool {
+	list := &llamav1alpha1.LlamaStackDistributionList{}
+	if err := c.List(ctx, list); err != nil {
+		return false
+	}
+
+	currentVersion := os.Getenv("OPERATOR_VERSION")
+	hasCRWithVersion := false
+
+	for _, cr := range list.Items {
+		if cr.Status.Version.OperatorVersion != "" {
+			hasCRWithVersion = true
+			if cr.Status.Version.OperatorVersion != currentVersion {
+				return true
+			}
+		}
+	}
+
+	return !hasCRWithVersion
+}
+
+// ensureDefaultFeatureFlags parses existing feature flags and adds any missing
+// flags with their default values while preserving user-set values. Returns the
+// updated YAML string and whether any changes were made.
+func ensureDefaultFeatureFlags(configMapData map[string]string) (string, bool) {
+	existing := make(map[string]interface{})
+	if yamlStr, ok := configMapData[featureflags.FeatureFlagsKey]; ok && yamlStr != "" {
+		if err := yaml.Unmarshal([]byte(yamlStr), &existing); err != nil {
+			// Corrupt YAML — replace with defaults
+			defaults := featureflags.FeatureFlags{
+				EnableNetworkPolicy: featureflags.FeatureFlag{Enabled: featureflags.NetworkPolicyDefaultValue},
+			}
+			out, _ := yaml.Marshal(defaults)
+			return string(out), true
+		}
+	}
+
+	changed := false
+
+	if _, ok := existing[featureflags.EnableNetworkPolicyKey]; !ok {
+		existing[featureflags.EnableNetworkPolicyKey] = map[string]interface{}{
+			"enabled": featureflags.NetworkPolicyDefaultValue,
+		}
+		changed = true
+	}
+
+	if !changed {
+		return configMapData[featureflags.FeatureFlagsKey], false
+	}
+
+	out, err := yaml.Marshal(existing)
+	if err != nil {
+		return configMapData[featureflags.FeatureFlagsKey], false
+	}
+	return string(out), true
 }
 
 func ParseImageMappingOverrides(ctx context.Context, configMapData map[string]string) map[string]string {

--- a/controllers/llamastackdistribution_controller_test.go
+++ b/controllers/llamastackdistribution_controller_test.go
@@ -12,6 +12,7 @@ import (
 	llamav1alpha1 "github.com/llamastack/llama-stack-k8s-operator/api/v1alpha1"
 	controllers "github.com/llamastack/llama-stack-k8s-operator/controllers"
 	"github.com/llamastack/llama-stack-k8s-operator/pkg/cluster"
+	"github.com/llamastack/llama-stack-k8s-operator/pkg/featureflags"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -902,7 +903,10 @@ func TestNewLlamaStackDistributionReconciler_WithImageOverrides(t *testing.T) {
 	require.Len(t, reconciler.ImageMappingOverrides, 1, "Should have one image override")
 	require.Equal(t, "quay.io/custom/llama-stack:starter",
 		reconciler.ImageMappingOverrides["starter"], "Override should match expected value")
-	require.False(t, reconciler.EnableNetworkPolicy, "Network policy should be disabled")
+	// initializeOperatorConfigMap preserves existing feature flag values and
+	// only fills in missing flags with defaults.
+	require.Equal(t, featureflags.NetworkPolicyDefaultValue, reconciler.EnableNetworkPolicy,
+		"Network policy should match the existing value in the ConfigMap")
 }
 
 func TestConfigMapUpdateTriggersReconciliation(t *testing.T) {
@@ -996,14 +1000,20 @@ func TestRefreshOperatorConfigPicksUpChanges(t *testing.T) {
 	operatorNamespace := createTestNamespace(t, "llama-stack-k8s-operator-system")
 	t.Setenv("OPERATOR_NAMESPACE", operatorNamespace.Name)
 
+	// Derive initial and toggled values from the compiled default so the test
+	// works regardless of the default (true in ODH/RHOAI, false upstream).
+	defaultEnabled := featureflags.NetworkPolicyDefaultValue
+	toggledEnabled := !defaultEnabled
+
+	// initializeOperatorConfigMap preserves existing feature flag values,
+	// so seed the ConfigMap with the default value for a clean baseline.
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "llama-stack-operator-config",
 			Namespace: operatorNamespace.Name,
 		},
 		Data: map[string]string{
-			"featureFlags": `enableNetworkPolicy:
-    enabled: false`,
+			"featureFlags": fmt.Sprintf("enableNetworkPolicy:\n    enabled: %t", defaultEnabled),
 		},
 	}
 	require.NoError(t, k8sClient.Create(t.Context(), configMap))
@@ -1029,17 +1039,21 @@ func TestRefreshOperatorConfigPicksUpChanges(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Initial reconcile creates resources.
+	// Initial reconcile creates resources with default feature flags.
 	_, err = reconciler.Reconcile(t.Context(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace},
 	})
 	require.NoError(t, err)
 
-	// Verify network policy is NOT created (feature disabled).
+	// Verify initial NetworkPolicy state matches the default.
 	networkPolicy := &networkingv1.NetworkPolicy{}
 	npName := instance.Name + "-network-policy"
-	err = k8sClient.Get(t.Context(), types.NamespacedName{Name: npName, Namespace: instance.Namespace}, networkPolicy)
-	require.True(t, apierrors.IsNotFound(err), "NetworkPolicy should not exist when feature is disabled")
+	if defaultEnabled {
+		waitForResource(t, k8sClient, instance.Namespace, npName, networkPolicy)
+	} else {
+		err = k8sClient.Get(t.Context(), types.NamespacedName{Name: npName, Namespace: instance.Namespace}, networkPolicy)
+		require.True(t, apierrors.IsNotFound(err), "NetworkPolicy should not exist when feature is disabled by default")
+	}
 
 	// Re-fetch the ConfigMap to get the latest resource version (initializeOperatorConfigMap
 	// may have updated it to add the watch label).
@@ -1048,9 +1062,8 @@ func TestRefreshOperatorConfigPicksUpChanges(t *testing.T) {
 		Namespace: configMap.Namespace,
 	}, configMap))
 
-	// Enable network policy via operator config update.
-	configMap.Data["featureFlags"] = `enableNetworkPolicy:
-    enabled: true`
+	// Toggle the network policy flag to the opposite value.
+	configMap.Data["featureFlags"] = fmt.Sprintf("enableNetworkPolicy:\n    enabled: %t", toggledEnabled)
 	require.NoError(t, k8sClient.Update(t.Context(), configMap))
 
 	// Reconcile again -- refreshOperatorConfig picks up the new flag.
@@ -1059,8 +1072,13 @@ func TestRefreshOperatorConfigPicksUpChanges(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Verify network policy IS created now.
-	waitForResource(t, k8sClient, instance.Namespace, npName, networkPolicy)
+	// Verify NetworkPolicy state reflects the toggled value.
+	if toggledEnabled {
+		waitForResource(t, k8sClient, instance.Namespace, npName, networkPolicy)
+	} else {
+		err = k8sClient.Get(t.Context(), types.NamespacedName{Name: npName, Namespace: instance.Namespace}, networkPolicy)
+		require.True(t, apierrors.IsNotFound(err), "NetworkPolicy should not exist when feature is disabled")
+	}
 }
 
 func TestReconcileRequeuesAfterSuccess(t *testing.T) {

--- a/pkg/featureflags/featureflags.go
+++ b/pkg/featureflags/featureflags.go
@@ -18,4 +18,7 @@ const (
 	EnableNetworkPolicyKey = "enableNetworkPolicy"
 	// NetworkPolicyDefaultValue is the default value for the network policy feature flag.
 	NetworkPolicyDefaultValue = false
+	// ResetOnUpgrade controls whether feature flags are reset to defaults on
+	// operator version change.
+	ResetOnUpgrade = false
 )


### PR DESCRIPTION
- Introduce ensureDefaultFeatureFlags, which parses the existing feature flags YAML and fills in only missing keys with their compiled defaults, preserving any user-customized values.

- Add a ResetOnUpgrade constant in pkg/featureflags (default false) that gates the full-reset behavior behind a build-time flag. When set to true (midstream), all flags are reset to defaults on operator version change via the existing needsConfigMapUpdate version-detection logic