### PR TITLE
feat(controller): add legacy resource adoption for OGXServer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,8 @@ docker-buildx: image-buildx ## Deprecated: use image-buildx instead
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p release
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default > release/operator.yaml
+	$(KUSTOMIZE) build config/overlays/cert-manager > release/operator.yaml
+	$(KUSTOMIZE) build config/overlays/openshift > release/operator-openshift.yaml
 
 .PHONY: image
 image: image-build image-push ## Build and push image with the manager.
@@ -296,13 +297,22 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: manifests kustomize ## Deploy controller to the K8s cluster (cert-manager overlay, vanilla K8s).
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/overlays/cert-manager | kubectl apply -f -
+
+.PHONY: deploy-openshift
+deploy-openshift: manifests kustomize ## Deploy controller to an OpenShift cluster (service-serving-cert-signer).
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/overlays/openshift | oc apply -f -
 
 .PHONY: undeploy
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUSTOMIZE) build config/overlays/cert-manager | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+
+.PHONY: undeploy-openshift
+undeploy-openshift: kustomize ## Undeploy controller from an OpenShift cluster. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUSTOMIZE) build config/overlays/openshift | oc delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Dependencies
 

--- a/api/v1beta1/ogxserver_types.go
+++ b/api/v1beta1/ogxserver_types.go
@@ -50,7 +50,10 @@ const (
 	AdoptStorageAnnotation = "ogx.io/adopt-storage"
 	// AdoptNetworkingAnnotation triggers Service/Ingress adoption from a legacy LlamaStackDistribution.
 	AdoptNetworkingAnnotation = "ogx.io/adopt-networking"
-	// AdoptedFromAnnotation is set on adopted child resources to record the legacy source.
+	// AdoptedFromLabel is set on adopted PVCs to record the legacy source.
+	// A label (not annotation) enables server-side filtering via MatchingLabels.
+	AdoptedFromLabel = "ogx.io/adopted-from"
+	// AdoptedFromAnnotation is set on adopted networking resources to record the legacy source.
 	AdoptedFromAnnotation = "ogx.io/adopted-from"
 	// AdoptedAtAnnotation is set on adopted child resources with an RFC 3339 timestamp.
 	AdoptedAtAnnotation = "ogx.io/adopted-at"

--- a/api/v1beta1/ogxserver_types.go
+++ b/api/v1beta1/ogxserver_types.go
@@ -631,7 +631,7 @@ func (r *OGXServer) GetAdoptNetworkingSource() string {
 // When the adopt-storage annotation is present, the adopted PVC name is "{legacyName}-pvc".
 // Otherwise the default convention is "{instanceName}-pvc".
 func (r *OGXServer) GetEffectivePVCName() string {
-	if src := r.GetAdoptStorageSource(); src != "" {
+	if src := r.GetAdoptStorageSource(); src != "" && ValidateAdoptionAnnotation(src) == nil {
 		return src + "-pvc"
 	}
 	return r.Name + "-pvc"

--- a/api/v1beta1/ogxserver_types.go
+++ b/api/v1beta1/ogxserver_types.go
@@ -50,11 +50,8 @@ const (
 	AdoptStorageAnnotation = "ogx.io/adopt-storage"
 	// AdoptNetworkingAnnotation triggers Service/Ingress adoption from a legacy LlamaStackDistribution.
 	AdoptNetworkingAnnotation = "ogx.io/adopt-networking"
-	// AdoptedFromLabel is set on adopted PVCs to record the legacy source.
-	// A label (not annotation) enables server-side filtering via MatchingLabels.
+	// AdoptedFromLabel is set on adopted resources to record the legacy source.
 	AdoptedFromLabel = "ogx.io/adopted-from"
-	// AdoptedFromAnnotation is set on adopted networking resources to record the legacy source.
-	AdoptedFromAnnotation = "ogx.io/adopted-from"
 	// AdoptedAtAnnotation is set on adopted child resources with an RFC 3339 timestamp.
 	AdoptedAtAnnotation = "ogx.io/adopted-at"
 )

--- a/api/v1beta1/ogxserver_webhook.go
+++ b/api/v1beta1/ogxserver_webhook.go
@@ -103,7 +103,28 @@ func (v *OGXServerValidator) collectValidationErrors(r *OGXServer) field.ErrorLi
 		allErrs = append(allErrs, validateProviderReferences(r.Spec.Resources, r.Spec.Providers)...)
 	}
 
+	allErrs = append(allErrs, validateAdoptionAnnotations(r)...)
+
 	return allErrs
+}
+
+// validateAdoptionAnnotations rejects adoption annotations whose value equals
+// the CR name. Same-name adoption causes Deployment name conflicts and is not
+// a supported migration path.
+func validateAdoptionAnnotations(r *OGXServer) field.ErrorList {
+	var errs field.ErrorList
+	annotationPath := field.NewPath("metadata", "annotations")
+
+	for _, key := range []string{AdoptStorageAnnotation, AdoptNetworkingAnnotation} {
+		if val, ok := r.Annotations[key]; ok && val == r.Name {
+			errs = append(errs, field.Invalid(
+				annotationPath.Key(key), val,
+				"adoption annotation value must not equal the CR name; same-name adoption causes resource conflicts",
+			))
+		}
+	}
+
+	return errs
 }
 
 // collectAllProviderIDs returns all provider IDs and any duplicate ID errors.

--- a/api/v1beta1/ogxserver_webhook_test.go
+++ b/api/v1beta1/ogxserver_webhook_test.go
@@ -19,6 +19,8 @@ package v1beta1
 import (
 	"strings"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestDeriveID(t *testing.T) {
@@ -455,6 +457,92 @@ func TestValidateDistributionName(t *testing.T) {
 	}
 }
 
+func TestValidateAdoptionAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		server      *OGXServer
+		wantErrs    int
+		errContains string
+	}{
+		{
+			name: "no adoption annotations is valid",
+			server: &OGXServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-server"},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "adopt-storage with different name is valid",
+			server: &OGXServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "new-server",
+					Annotations: map[string]string{AdoptStorageAnnotation: "old-server"},
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "adopt-storage equals CR name is rejected",
+			server: &OGXServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-server",
+					Annotations: map[string]string{AdoptStorageAnnotation: "my-server"},
+				},
+			},
+			wantErrs:    1,
+			errContains: "must not equal the CR name",
+		},
+		{
+			name: "adopt-networking equals CR name is rejected",
+			server: &OGXServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-server",
+					Annotations: map[string]string{AdoptNetworkingAnnotation: "my-server"},
+				},
+			},
+			wantErrs:    1,
+			errContains: "must not equal the CR name",
+		},
+		{
+			name: "both annotations equal CR name gives two errors",
+			server: &OGXServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-server",
+					Annotations: map[string]string{
+						AdoptStorageAnnotation:    "my-server",
+						AdoptNetworkingAnnotation: "my-server",
+					},
+				},
+			},
+			wantErrs: 2,
+		},
+		{
+			name: "adopt-networking with different name is valid",
+			server: &OGXServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "new-server",
+					Annotations: map[string]string{AdoptNetworkingAnnotation: "old-server"},
+				},
+			},
+			wantErrs: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateAdoptionAnnotations(tt.server)
+			if len(errs) != tt.wantErrs {
+				t.Errorf("validateAdoptionAnnotations() returned %d errors, want %d: %v", len(errs), tt.wantErrs, errs)
+			}
+			if tt.errContains != "" && len(errs) > 0 {
+				if !strings.Contains(errs[0].Detail, tt.errContains) {
+					t.Errorf("error detail %q does not contain %q", errs[0].Detail, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
 func TestCollectValidationErrors(t *testing.T) {
 	knownNames := []string{"starter", "remote-vllm"}
 
@@ -529,6 +617,19 @@ func TestCollectValidationErrors(t *testing.T) {
 				},
 			},
 			wantErrs: 0,
+		},
+		{
+			name: "self-adoption annotation is rejected",
+			server: &OGXServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-server",
+					Annotations: map[string]string{AdoptStorageAnnotation: "my-server"},
+				},
+				Spec: OGXServerSpec{
+					Distribution: DistributionSpec{Name: "starter"},
+				},
+			},
+			wantErrs: 1,
 		},
 	}
 

--- a/api/v1beta1/provider_types_inference.go
+++ b/api/v1beta1/provider_types_inference.go
@@ -173,11 +173,12 @@ func (p AzureProvider) DeriveID() string { return p.deriveOrDefault("remote-azur
 
 // BedrockProvider configures a remote::bedrock inference provider instance.
 // +kubebuilder:validation:XValidation:rule="!has(self.awsRoleArn) || self.awsRoleArn.size() > 0",message="awsRoleArn must not be empty if specified"
-//nolint:lll // kubebuilder marker cannot be split across lines.
 // +kubebuilder:validation:XValidation:rule="!has(self.awsWebIdentityTokenFile) || self.awsWebIdentityTokenFile.size() > 0",message="awsWebIdentityTokenFile must not be empty if specified"
 // +kubebuilder:validation:XValidation:rule="!has(self.awsRoleSessionName) || self.awsRoleSessionName.size() > 0",message="awsRoleSessionName must not be empty if specified"
 // +kubebuilder:validation:XValidation:rule="!has(self.profileName) || self.profileName.size() > 0",message="profileName must not be empty if specified"
 // +kubebuilder:validation:XValidation:rule="!has(self.retryMode) || self.retryMode.size() > 0",message="retryMode must not be empty if specified"
+//
+//nolint:lll // kubebuilder marker cannot be split across lines.
 type BedrockProvider struct {
 	RoutedProviderBase          `json:",inline"`
 	RemoteInferenceCommonConfig `json:",inline"`

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: ogx-k8s-operator-system
+namePrefix: ogx-k8s-operator-
+
 resources:
 - certificate.yaml
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -8,9 +8,6 @@ resources:
 - bases/ogx.io_ogxservers.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patches:
-- path: patches/cainjection_in_ogxservers.yaml
-
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,7 +16,6 @@ resources:
 - ../rbac
 - ../manager
 - ../webhook
-- ../certmanager
 
 labels:
 - includeSelectors: true
@@ -30,89 +29,7 @@ labels:
 
 patches:
 - path: manager_webhook_patch.yaml
-- target:
-    kind: ValidatingWebhookConfiguration
-  patch: |-
-    - op: add
-      path: /metadata/annotations
-      value:
-        cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
 #- manager_config_patch.yaml
-
-# the following config is for teaching kustomize how to do var substitution
-replacements:
-- source:
-    kind: Service
-    version: v1
-    name: webhook-service
-    fieldPath: metadata.name
-  targets:
-  - select:
-      kind: Certificate
-      group: cert-manager.io
-    fieldPaths:
-    - spec.dnsNames.0
-    - spec.dnsNames.1
-    options:
-      delimiter: "."
-      index: 0
-- source:
-    kind: Service
-    version: v1
-    name: webhook-service
-    fieldPath: metadata.namespace
-  targets:
-  - select:
-      kind: Certificate
-      group: cert-manager.io
-    fieldPaths:
-    - spec.dnsNames.0
-    - spec.dnsNames.1
-    options:
-      delimiter: "."
-      index: 1
-- source:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert
-    fieldPath: metadata.namespace
-  targets:
-  - select:
-      kind: CustomResourceDefinition
-    fieldPaths:
-    - metadata.annotations.[cert-manager.io/inject-ca-from]
-    options:
-      delimiter: "/"
-      index: 0
-  - select:
-      kind: ValidatingWebhookConfiguration
-    fieldPaths:
-    - metadata.annotations.[cert-manager.io/inject-ca-from]
-    options:
-      delimiter: "/"
-      index: 0
-- source:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert
-    fieldPath: metadata.name
-  targets:
-  - select:
-      kind: CustomResourceDefinition
-    fieldPaths:
-    - metadata.annotations.[cert-manager.io/inject-ca-from]
-    options:
-      delimiter: "/"
-      index: 1
-  - select:
-      kind: ValidatingWebhookConfiguration
-    fieldPaths:
-    - metadata.annotations.[cert-manager.io/inject-ca-from]
-    options:
-      delimiter: "/"
-      index: 1

--- a/config/overlays/cert-manager/cainjection_in_ogxservers.yaml
+++ b/config/overlays/cert-manager/cainjection_in_ogxservers.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: ogxservers.ogx.io

--- a/config/overlays/cert-manager/kustomization.yaml
+++ b/config/overlays/cert-manager/kustomization.yaml
@@ -1,0 +1,98 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Overlay for vanilla Kubernetes clusters using cert-manager for webhook TLS.
+# Adds cert-manager Issuer/Certificate resources and wires CA injection into
+# the ValidatingWebhookConfiguration and CRD annotations.
+
+resources:
+- ../../default
+- ../../certmanager
+
+patches:
+# Inject cert-manager CA bundle annotation on the CRD.
+- path: cainjection_in_ogxservers.yaml
+# Inject cert-manager CA bundle annotation on the webhook configuration.
+- target:
+    kind: ValidatingWebhookConfiguration
+  patch: |-
+    - op: add
+      path: /metadata/annotations
+      value:
+        cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
+
+# Replacements wire the webhook Service name/namespace into the Certificate
+# dnsNames and the Certificate namespace/name into CA injection annotations.
+replacements:
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+    fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: "."
+      index: 0
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+    fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: "."
+      index: 1
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: CustomResourceDefinition
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: "/"
+      index: 0
+  - select:
+      kind: ValidatingWebhookConfiguration
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: "/"
+      index: 0
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: CustomResourceDefinition
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: "/"
+      index: 1
+  - select:
+      kind: ValidatingWebhookConfiguration
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: "/"
+      index: 1

--- a/config/overlays/openshift/kustomization.yaml
+++ b/config/overlays/openshift/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Overlay for OpenShift clusters using the built-in service-serving-cert-signer.
+# No cert-manager dependency is required. The platform automatically:
+# 1. Generates a TLS Secret for the webhook Service via the serving-cert annotation.
+# 2. Injects the CA bundle into the ValidatingWebhookConfiguration.
+
+resources:
+- ../../default
+
+patches:
+# Annotate the webhook Service so OpenShift's service-serving-cert-signer
+# generates a TLS certificate into the named Secret.
+- target:
+    kind: Service
+    name: webhook-service
+  patch: |-
+    - op: add
+      path: /metadata/annotations
+      value:
+        service.beta.openshift.io/serving-cert-secret-name: ogx-k8s-operator-webhook-cert
+# Annotate the ValidatingWebhookConfiguration so OpenShift injects the
+# service-ca CA bundle into webhooks[].clientConfig.caBundle.
+- target:
+    kind: ValidatingWebhookConfiguration
+  patch: |-
+    - op: add
+      path: /metadata/annotations
+      value:
+        service.beta.openshift.io/inject-cabundle: "true"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,22 +8,9 @@ rules:
   - ""
   resources:
   - configmaps
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - persistentvolumeclaims
-  - serviceaccounts
-  - services
   verbs:
   - create
-  - delete
   - get
   - list
   - patch
@@ -35,6 +22,19 @@ rules:
   - pods
   verbs:
   - list
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,21 +19,6 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-- apiGroups:
-  - ""
-  resources:
   - serviceaccounts
   - services
   verbs:
@@ -44,6 +29,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
 - apiGroups:
   - apps
   resources:

--- a/controllers/kubebuilder_rbac.go
+++ b/controllers/kubebuilder_rbac.go
@@ -27,7 +27,7 @@ package controllers
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=anyuid,verbs=use
 
-//+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch
 
 // ConfigMap permissions - controller reads user configmaps and manages operator config configmaps
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch

--- a/controllers/kubebuilder_rbac.go
+++ b/controllers/kubebuilder_rbac.go
@@ -27,7 +27,7 @@ package controllers
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=anyuid,verbs=use
 
-//+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update
+//+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 
 // ConfigMap permissions - controller reads user configmaps and manages operator config configmaps
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch

--- a/controllers/legacy_adoption.go
+++ b/controllers/legacy_adoption.go
@@ -288,12 +288,11 @@ func (r *OGXServerReconciler) adoptLegacyService(ctx context.Context, instance *
 		return true, nil
 	}
 
-	// Update selectors to route traffic to new pods.
-	if svc.Spec.Selector == nil {
-		svc.Spec.Selector = make(map[string]string)
+	// Replace selectors to route traffic to new pods.
+	svc.Spec.Selector = map[string]string{
+		ogxiov1beta1.DefaultLabelKey: ogxiov1beta1.DefaultLabelValue,
+		instanceLabelKey:             instance.Name,
 	}
-	svc.Spec.Selector[ogxiov1beta1.DefaultLabelKey] = ogxiov1beta1.DefaultLabelValue
-	svc.Spec.Selector[instanceLabelKey] = instance.Name
 
 	if err := r.transferOwnership(ctx, instance, svc, legacyName); err != nil {
 		return false, err
@@ -403,12 +402,18 @@ func (r *OGXServerReconciler) transferOwnership(ctx context.Context, instance *o
 	}
 	obj.SetOwnerReferences(filtered)
 
-	// Set adoption audit annotations.
+	// Set adoption audit label and timestamp annotation.
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[ogxiov1beta1.AdoptedFromLabel] = legacySource
+	obj.SetLabels(labels)
+
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
-	annotations[ogxiov1beta1.AdoptedFromAnnotation] = legacySource
 	annotations[ogxiov1beta1.AdoptedAtAnnotation] = metav1.Now().UTC().Format(time.RFC3339)
 	obj.SetAnnotations(annotations)
 
@@ -458,13 +463,13 @@ func (r *OGXServerReconciler) cleanupAdoptedNetworking(ctx context.Context, inst
 func (r *OGXServerReconciler) cleanupAdoptedServices(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
 	logger := log.FromContext(ctx)
 	ownedServices := &corev1.ServiceList{}
-	if err := r.List(ctx, ownedServices, client.InNamespace(instance.Namespace)); err != nil {
+	if err := r.List(ctx, ownedServices, client.InNamespace(instance.Namespace), client.HasLabels{ogxiov1beta1.AdoptedFromLabel}); err != nil {
 		return fmt.Errorf("failed to list services for adoption cleanup: %w", err)
 	}
 
 	for i := range ownedServices.Items {
 		svc := &ownedServices.Items[i]
-		if !shouldDeleteAdoptedResource(instance, svc.GetAnnotations(), svc) {
+		if !shouldDeleteAdoptedResource(instance, svc) {
 			continue
 		}
 		logger.Info("Deleting adopted legacy Service after annotation removal", "service", svc.Name)
@@ -479,13 +484,13 @@ func (r *OGXServerReconciler) cleanupAdoptedServices(ctx context.Context, instan
 func (r *OGXServerReconciler) cleanupAdoptedIngresses(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
 	logger := log.FromContext(ctx)
 	ownedIngresses := &networkingv1.IngressList{}
-	if err := r.List(ctx, ownedIngresses, client.InNamespace(instance.Namespace)); err != nil {
+	if err := r.List(ctx, ownedIngresses, client.InNamespace(instance.Namespace), client.HasLabels{ogxiov1beta1.AdoptedFromLabel}); err != nil {
 		return fmt.Errorf("failed to list ingresses for adoption cleanup: %w", err)
 	}
 
 	for i := range ownedIngresses.Items {
 		ing := &ownedIngresses.Items[i]
-		if !shouldDeleteAdoptedResource(instance, ing.GetAnnotations(), ing) {
+		if !shouldDeleteAdoptedResource(instance, ing) {
 			continue
 		}
 		logger.Info("Deleting adopted legacy Ingress after annotation removal", "ingress", ing.Name)
@@ -499,13 +504,12 @@ func (r *OGXServerReconciler) cleanupAdoptedIngresses(ctx context.Context, insta
 
 func shouldDeleteAdoptedResource(
 	instance *ogxiov1beta1.OGXServer,
-	annotations map[string]string,
 	obj metav1.Object,
 ) bool {
 	if !metav1.IsControlledBy(obj, instance) {
 		return false
 	}
-	_, hasAdopted := annotations[ogxiov1beta1.AdoptedFromAnnotation]
+	_, hasAdopted := obj.GetLabels()[ogxiov1beta1.AdoptedFromLabel]
 	return hasAdopted
 }
 
@@ -586,7 +590,20 @@ func (r *OGXServerReconciler) resolveEffectivePVCName(ctx context.Context, insta
 		return "", fmt.Errorf("failed to list adopted PVCs: %w", err)
 	}
 
-	if len(pvcList.Items) > 0 {
+	if len(pvcList.Items) > 1 {
+		names := make([]string, len(pvcList.Items))
+		for i := range pvcList.Items {
+			names[i] = pvcList.Items[i].Name
+		}
+		msg := fmt.Sprintf("multiple adopted PVCs found for instance %q: %v; remove the %s label from all but one",
+			instance.Name, names, ogxiov1beta1.AdoptedFromLabel)
+		logger := log.FromContext(ctx)
+		logger.Error(nil, msg)
+		SetAdoptionConfigInvalidCondition(&instance.Status, msg)
+		return "", &terminalError{message: msg}
+	}
+
+	if len(pvcList.Items) == 1 {
 		return pvcList.Items[0].Name, nil
 	}
 

--- a/controllers/legacy_adoption.go
+++ b/controllers/legacy_adoption.go
@@ -154,9 +154,9 @@ func (r *OGXServerReconciler) adoptNetworkingSource(
 	return nil
 }
 
-// adoptStorage transfers ownership of a legacy PVC to this OGXServer CR.
-// If the old Deployment is still running, it is scaled to zero first
-// (requeue is requested to wait for pod termination).
+// adoptStorage detaches a legacy PVC from its old controller and labels it
+// for discovery by this OGXServer. No ownerRef is set on the PVC
+// The Deployment references the PVC by name via GetEffectivePVCName().
 func (r *OGXServerReconciler) adoptStorage(ctx context.Context, instance *ogxiov1beta1.OGXServer, legacyName string) (adoptionResult, error) {
 	logger := log.FromContext(ctx)
 	result := adoptionResult{}
@@ -173,8 +173,8 @@ func (r *OGXServerReconciler) adoptStorage(ctx context.Context, instance *ogxiov
 		return result, fmt.Errorf("failed to get legacy PVC %s: %w", pvcName, err)
 	}
 
-	// Idempotency: already owned by this CR.
-	if metav1.IsControlledBy(pvc, instance) {
+	// Idempotency: check adoption label instead of ownerRef.
+	if pvc.Labels != nil && pvc.Labels[ogxiov1beta1.AdoptedFromLabel] == legacyName {
 		logger.V(1).Info("Legacy PVC already adopted", "pvc", pvcName)
 		SetStorageAdoptedCondition(&instance.Status, true, fmt.Sprintf("PVC %s adopted", pvcName))
 		return result, nil
@@ -192,14 +192,63 @@ func (r *OGXServerReconciler) adoptStorage(ctx context.Context, instance *ogxiov
 		return result, nil
 	}
 
-	// Transfer ownership: remove any existing controller ownerRef, then set ours.
-	if err := r.transferOwnership(ctx, instance, pvc, legacyName); err != nil {
+	// Detach from old controller and label for discovery. No new ownerRef is set.
+	if err := r.detachAndLabelPVC(ctx, instance.Name, pvc, legacyName); err != nil {
 		return result, err
 	}
 
 	SetStorageAdoptedCondition(&instance.Status, true, fmt.Sprintf("PVC %s adopted", pvcName))
 	logger.Info("Successfully adopted legacy PVC", "pvc", pvcName)
 	return result, nil
+}
+
+// detachAndLabelPVC removes the legacy controller ownerRef from the PVC and
+// sets the adopted-from label for server-side discovery. No new ownerRef is
+// added — PVCs must outlive OGXServer deletion.
+func (r *OGXServerReconciler) detachAndLabelPVC(ctx context.Context, instanceName string, pvc *corev1.PersistentVolumeClaim, legacySource string) error {
+	controllerRef := metav1.GetControllerOf(pvc)
+	if controllerRef != nil && !isExpectedLegacyOwnerRef(controllerRef, legacySource) {
+		return fmt.Errorf(
+			"failed to adopt %s: unexpected controller owner %s/%s %q",
+			pvc.Name, controllerRef.APIVersion, controllerRef.Kind, controllerRef.Name,
+		)
+	}
+
+	// Strip old controller ownerRef.
+	ownerRefs := pvc.GetOwnerReferences()
+	filtered := make([]metav1.OwnerReference, 0, len(ownerRefs))
+	for i := range ownerRefs {
+		if ownerRefs[i].Controller != nil && *ownerRefs[i].Controller {
+			continue
+		}
+		filtered = append(filtered, ownerRefs[i])
+	}
+	pvc.SetOwnerReferences(filtered)
+
+	// Set adoption label for server-side discovery, and instance label to
+	// scope the PVC to the specific OGXServer (avoids cross-instance ambiguity
+	// when multiple OGXServers share a namespace).
+	labels := pvc.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[ogxiov1beta1.AdoptedFromLabel] = legacySource
+	labels[instanceLabelKey] = instanceName
+	pvc.SetLabels(labels)
+
+	// Set adoption audit annotation.
+	annotations := pvc.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[ogxiov1beta1.AdoptedAtAnnotation] = metav1.Now().UTC().Format(time.RFC3339)
+	pvc.SetAnnotations(annotations)
+
+	if err := r.Update(ctx, pvc); err != nil {
+		return fmt.Errorf("failed to update %s after adoption: %w", pvc.Name, err)
+	}
+
+	return nil
 }
 
 // adoptNetworking transfers ownership of a legacy Service and Ingress to this OGXServer CR.
@@ -517,6 +566,31 @@ func clearAdoptionConfigInvalidCondition(status *ogxiov1beta1.OGXServerStatus) {
 		Message:            "Adoption annotations are valid",
 		LastTransitionTime: metav1.NewTime(metav1.Now().UTC()),
 	})
+}
+
+// resolveEffectivePVCName determines the PVC name the reconciler should use:
+//  1. If adopt-storage annotation is present, the adopted PVC name is "{legacyName}-pvc".
+//  2. If the annotation is absent, discover an already-adopted PVC by the AdoptedFromLabel.
+//  3. Otherwise, fall back to the default "{instanceName}-pvc".
+func (r *OGXServerReconciler) resolveEffectivePVCName(ctx context.Context, instance *ogxiov1beta1.OGXServer) (string, error) {
+	if src := instance.GetAdoptStorageSource(); src != "" && ogxiov1beta1.ValidateAdoptionAnnotation(src) == nil {
+		return src + "-pvc", nil
+	}
+
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := r.List(ctx, pvcList,
+		client.InNamespace(instance.Namespace),
+		client.HasLabels{ogxiov1beta1.AdoptedFromLabel},
+		client.MatchingLabels{instanceLabelKey: instance.Name},
+	); err != nil {
+		return "", fmt.Errorf("failed to list adopted PVCs: %w", err)
+	}
+
+	if len(pvcList.Items) > 0 {
+		return pvcList.Items[0].Name, nil
+	}
+
+	return instance.Name + "-pvc", nil
 }
 
 func isExpectedLegacyOwnerRef(ownerRef *metav1.OwnerReference, legacyName string) bool {

--- a/controllers/legacy_adoption.go
+++ b/controllers/legacy_adoption.go
@@ -1,0 +1,527 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	legacyv1alpha1 "github.com/ogx-ai/ogx-k8s-operator/api/v1alpha1"
+	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// adoptionResult carries the outcome of a single adoption pass.
+type adoptionResult struct {
+	requeue      bool
+	requeueAfter time.Duration
+}
+
+// adoptLegacyResources processes adoption annotations and transfers ownership
+// of legacy LlamaStackDistribution resources to this OGXServer CR.
+// Returns (needsRequeue, error). A requeue is requested when the old Deployment
+// has been scaled to zero but pods are still terminating.
+func (r *OGXServerReconciler) adoptLegacyResources(ctx context.Context, instance *ogxiov1beta1.OGXServer) (adoptionResult, error) {
+	logger := log.FromContext(ctx).WithValues("adoption", true)
+	ctx = ctrl.LoggerInto(ctx, logger)
+
+	result := adoptionResult{}
+
+	storageSource := instance.GetAdoptStorageSource()
+	networkingSource := instance.GetAdoptNetworkingSource()
+
+	// Always clear stale invalid condition when there are no active annotations.
+	if storageSource == "" && networkingSource == "" {
+		clearAdoptionConfigInvalidCondition(&instance.Status)
+		return result, nil
+	}
+
+	// Validate annotations before any adoption work.
+	if !validateAdoptionSources(ctx, &instance.Status, storageSource, networkingSource) {
+		return result, nil
+	}
+
+	// Clear any previous AdoptionConfigInvalid condition.
+	clearAdoptionConfigInvalidCondition(&instance.Status)
+
+	storageResult, err := r.adoptStorageSource(ctx, instance, storageSource)
+	if err != nil {
+		return result, err
+	}
+	if storageResult.requeue {
+		result = storageResult
+	}
+
+	if err := r.adoptNetworkingSource(ctx, instance, networkingSource); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func validateAdoptionSources(
+	ctx context.Context,
+	status *ogxiov1beta1.OGXServerStatus,
+	storageSource, networkingSource string,
+) bool {
+	if !validateAdoptionSource(ctx, status, "adopt-storage", storageSource) {
+		return false
+	}
+
+	return validateAdoptionSource(ctx, status, "adopt-networking", networkingSource)
+}
+
+func validateAdoptionSource(
+	ctx context.Context,
+	status *ogxiov1beta1.OGXServerStatus,
+	annotationName, value string,
+) bool {
+	if value == "" {
+		return true
+	}
+
+	if err := ogxiov1beta1.ValidateAdoptionAnnotation(value); err != nil {
+		logger := log.FromContext(ctx)
+		logger.Error(err, "invalid adoption annotation value", "annotation", annotationName, "value", value)
+		SetAdoptionConfigInvalidCondition(status, fmt.Sprintf("%s: %v", annotationName, err))
+		return false
+	}
+
+	return true
+}
+
+func (r *OGXServerReconciler) adoptStorageSource(
+	ctx context.Context,
+	instance *ogxiov1beta1.OGXServer,
+	storageSource string,
+) (adoptionResult, error) {
+	if storageSource == "" {
+		return adoptionResult{}, nil
+	}
+
+	storageResult, err := r.adoptStorage(ctx, instance, storageSource)
+	if err != nil {
+		return adoptionResult{}, fmt.Errorf("failed to adopt storage from %q: %w", storageSource, err)
+	}
+
+	return storageResult, nil
+}
+
+func (r *OGXServerReconciler) adoptNetworkingSource(
+	ctx context.Context,
+	instance *ogxiov1beta1.OGXServer,
+	networkingSource string,
+) error {
+	if networkingSource == "" {
+		return nil
+	}
+
+	if err := r.adoptNetworking(ctx, instance, networkingSource); err != nil {
+		return fmt.Errorf("failed to adopt networking from %q: %w", networkingSource, err)
+	}
+
+	return nil
+}
+
+// adoptStorage transfers ownership of a legacy PVC to this OGXServer CR.
+// If the old Deployment is still running, it is scaled to zero first
+// (requeue is requested to wait for pod termination).
+func (r *OGXServerReconciler) adoptStorage(ctx context.Context, instance *ogxiov1beta1.OGXServer, legacyName string) (adoptionResult, error) {
+	logger := log.FromContext(ctx)
+	result := adoptionResult{}
+
+	pvcName := legacyName + "-pvc"
+	pvc := &corev1.PersistentVolumeClaim{}
+	pvcKey := types.NamespacedName{Name: pvcName, Namespace: instance.Namespace}
+
+	if err := r.Get(ctx, pvcKey, pvc); err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.Info("Legacy PVC not found, skipping storage adoption", "pvc", pvcName)
+			return result, nil
+		}
+		return result, fmt.Errorf("failed to get legacy PVC %s: %w", pvcName, err)
+	}
+
+	// Idempotency: already owned by this CR.
+	if metav1.IsControlledBy(pvc, instance) {
+		logger.V(1).Info("Legacy PVC already adopted", "pvc", pvcName)
+		SetStorageAdoptedCondition(&instance.Status, true, fmt.Sprintf("PVC %s adopted", pvcName))
+		return result, nil
+	}
+
+	// Scale legacy Deployment to zero if it still exists, to release the RWO PVC.
+	requeue, err := r.scaleDownLegacyDeployment(ctx, instance.Namespace, legacyName)
+	if err != nil {
+		return result, err
+	}
+	if requeue {
+		result.requeue = true
+		result.requeueAfter = 5 * time.Second
+		logger.Info("Waiting for legacy pods to terminate before PVC adoption", "deployment", legacyName)
+		return result, nil
+	}
+
+	// Transfer ownership: remove any existing controller ownerRef, then set ours.
+	if err := r.transferOwnership(ctx, instance, pvc, legacyName); err != nil {
+		return result, err
+	}
+
+	SetStorageAdoptedCondition(&instance.Status, true, fmt.Sprintf("PVC %s adopted", pvcName))
+	logger.Info("Successfully adopted legacy PVC", "pvc", pvcName)
+	return result, nil
+}
+
+// adoptNetworking transfers ownership of a legacy Service and Ingress to this OGXServer CR.
+func (r *OGXServerReconciler) adoptNetworking(ctx context.Context, instance *ogxiov1beta1.OGXServer, legacyName string) error {
+	serviceAdopted, err := r.adoptLegacyService(ctx, instance, legacyName)
+	if err != nil {
+		return err
+	}
+	ingressAdopted, err := r.adoptLegacyIngress(ctx, instance, legacyName)
+	if err != nil {
+		return err
+	}
+
+	if serviceAdopted || ingressAdopted {
+		SetNetworkingAdoptedCondition(&instance.Status, true, fmt.Sprintf("Networking adopted from %s", legacyName))
+	}
+
+	return nil
+}
+
+func (r *OGXServerReconciler) adoptLegacyService(ctx context.Context, instance *ogxiov1beta1.OGXServer, legacyName string) (bool, error) {
+	logger := log.FromContext(ctx)
+	serviceName := legacyName + "-service"
+	svc := &corev1.Service{}
+	svcKey := types.NamespacedName{Name: serviceName, Namespace: instance.Namespace}
+
+	if err := r.Get(ctx, svcKey, svc); err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.Info("Legacy Service not found, skipping", "service", serviceName)
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get legacy Service %s: %w", serviceName, err)
+	}
+
+	if metav1.IsControlledBy(svc, instance) {
+		logger.V(1).Info("Legacy Service already adopted", "service", serviceName)
+		return true, nil
+	}
+
+	// Update selectors to route traffic to new pods.
+	if svc.Spec.Selector == nil {
+		svc.Spec.Selector = make(map[string]string)
+	}
+	svc.Spec.Selector[ogxiov1beta1.DefaultLabelKey] = ogxiov1beta1.DefaultLabelValue
+	svc.Spec.Selector[instanceLabelKey] = instance.Name
+
+	if err := r.transferOwnership(ctx, instance, svc, legacyName); err != nil {
+		return false, err
+	}
+	logger.Info("Successfully adopted legacy Service", "service", serviceName)
+
+	return true, nil
+}
+
+func (r *OGXServerReconciler) adoptLegacyIngress(ctx context.Context, instance *ogxiov1beta1.OGXServer, legacyName string) (bool, error) {
+	logger := log.FromContext(ctx)
+	ingressName := legacyName + "-ingress"
+	ingress := &networkingv1.Ingress{}
+	ingressKey := types.NamespacedName{Name: ingressName, Namespace: instance.Namespace}
+
+	if err := r.Get(ctx, ingressKey, ingress); err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.Info("Legacy Ingress not found, skipping", "ingress", ingressName)
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get legacy Ingress %s: %w", ingressName, err)
+	}
+
+	if metav1.IsControlledBy(ingress, instance) {
+		logger.V(1).Info("Legacy Ingress already adopted", "ingress", ingressName)
+		return true, nil
+	}
+
+	if err := r.transferOwnership(ctx, instance, ingress, legacyName); err != nil {
+		return false, err
+	}
+	logger.Info("Successfully adopted legacy Ingress", "ingress", ingressName)
+
+	return true, nil
+}
+
+// scaleDownLegacyDeployment scales the legacy Deployment to zero and returns
+// true if a requeue is needed to wait for pod termination.
+func (r *OGXServerReconciler) scaleDownLegacyDeployment(ctx context.Context, namespace, legacyName string) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	deployment := &appsv1.Deployment{}
+	key := types.NamespacedName{Name: legacyName, Namespace: namespace}
+
+	if err := r.Get(ctx, key, deployment); err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.V(1).Info("Legacy Deployment not found, proceeding with PVC adoption", "deployment", legacyName)
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get legacy Deployment %s: %w", legacyName, err)
+	}
+
+	// Scale to zero if not already.
+	zero := int32(0)
+	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 0 {
+		logger.Info("Scaling legacy Deployment to zero", "deployment", legacyName)
+		patch := client.MergeFrom(deployment.DeepCopy())
+		deployment.Spec.Replicas = &zero
+		if err := r.Patch(ctx, deployment, patch); err != nil {
+			return false, fmt.Errorf("failed to scale down legacy Deployment %s: %w", legacyName, err)
+		}
+	}
+
+	// Check if pods are still running.
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{instanceLabelKey: legacyName},
+	); err != nil {
+		return false, fmt.Errorf("failed to list pods for legacy Deployment %s: %w", legacyName, err)
+	}
+
+	if len(podList.Items) > 0 {
+		logger.Info("Legacy pods still terminating", "deployment", legacyName, "podCount", len(podList.Items))
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// transferOwnership removes the existing controller ownerRef (if any) and sets
+// this OGXServer as the new controller owner. Also annotates the resource with
+// adoption audit metadata. legacySource is the LLSD name the resource was
+// adopted from (used in the ogx.io/adopted-from annotation).
+func (r *OGXServerReconciler) transferOwnership(ctx context.Context, instance *ogxiov1beta1.OGXServer, obj client.Object, legacySource string) error {
+	resourceName := obj.GetName()
+	controllerRef := metav1.GetControllerOf(obj)
+
+	// Safety check: only take over resources that are currently controlled by
+	// the expected legacy LLSD controller. This avoids accidental takeover of
+	// unrelated resources that happen to share names.
+	if controllerRef != nil && !isExpectedLegacyOwnerRef(controllerRef, legacySource) {
+		return fmt.Errorf(
+			"failed to adopt %s: unexpected controller owner %s/%s %q",
+			resourceName, controllerRef.APIVersion, controllerRef.Kind, controllerRef.Name,
+		)
+	}
+
+	// Remove existing controller ownerRef.
+	ownerRefs := obj.GetOwnerReferences()
+	filtered := make([]metav1.OwnerReference, 0, len(ownerRefs))
+	for i := range ownerRefs {
+		if ownerRefs[i].Controller != nil && *ownerRefs[i].Controller {
+			continue
+		}
+		filtered = append(filtered, ownerRefs[i])
+	}
+	obj.SetOwnerReferences(filtered)
+
+	// Set adoption audit annotations.
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[ogxiov1beta1.AdoptedFromAnnotation] = legacySource
+	annotations[ogxiov1beta1.AdoptedAtAnnotation] = metav1.Now().UTC().Format(time.RFC3339)
+	obj.SetAnnotations(annotations)
+
+	// Set new controller ownerRef.
+	if err := ctrl.SetControllerReference(instance, obj, r.Scheme); err != nil {
+		return fmt.Errorf("failed to set controller reference on %s: %w", resourceName, err)
+	}
+
+	if err := r.Update(ctx, obj); err != nil {
+		return fmt.Errorf("failed to update %s after ownership transfer: %w", resourceName, err)
+	}
+
+	return nil
+}
+
+// cleanupAdoptedNetworking deletes adopted legacy networking resources when the
+// adopt-networking annotation is removed and the CR name differs from the legacy
+// name (different-name case). In the same-name case, the resources have the same
+// names as what the kustomize pipeline creates, so they are managed normally.
+func (r *OGXServerReconciler) cleanupAdoptedNetworking(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
+	// Only clean up if the annotation has been removed.
+	if instance.GetAdoptNetworkingSource() != "" {
+		return nil
+	}
+	// if this instance never reported networking adoption, there is
+	// nothing to clean up.
+	if !IsConditionTrue(&instance.Status, ConditionTypeNetworkingAdopted) {
+		return nil
+	}
+
+	if err := r.cleanupAdoptedServices(ctx, instance); err != nil {
+		return err
+	}
+
+	if err := r.cleanupAdoptedIngresses(ctx, instance); err != nil {
+		return err
+	}
+
+	// Cleanup pass completed successfully and adoption annotation is absent;
+	// clear condition to avoid repeated full namespace scans on steady-state
+	// reconciliations.
+	SetNetworkingAdoptedCondition(&instance.Status, false, "Adoption annotation removed")
+
+	return nil
+}
+
+func (r *OGXServerReconciler) cleanupAdoptedServices(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
+	logger := log.FromContext(ctx)
+	ownedServices := &corev1.ServiceList{}
+	if err := r.List(ctx, ownedServices, client.InNamespace(instance.Namespace)); err != nil {
+		return fmt.Errorf("failed to list services for adoption cleanup: %w", err)
+	}
+
+	for i := range ownedServices.Items {
+		svc := &ownedServices.Items[i]
+		if !shouldDeleteAdoptedResource(svc.GetName(), instance, instance.Name+"-service", svc.GetAnnotations(), svc) {
+			continue
+		}
+		logger.Info("Deleting adopted legacy Service after annotation removal", "service", svc.Name)
+		if err := r.Delete(ctx, svc); err != nil && !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete adopted Service %s: %w", svc.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *OGXServerReconciler) cleanupAdoptedIngresses(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
+	logger := log.FromContext(ctx)
+	ownedIngresses := &networkingv1.IngressList{}
+	if err := r.List(ctx, ownedIngresses, client.InNamespace(instance.Namespace)); err != nil {
+		return fmt.Errorf("failed to list ingresses for adoption cleanup: %w", err)
+	}
+
+	for i := range ownedIngresses.Items {
+		ing := &ownedIngresses.Items[i]
+		if !shouldDeleteAdoptedResource(ing.GetName(), instance, instance.Name+IngressNameSuffix, ing.GetAnnotations(), ing) {
+			continue
+		}
+		logger.Info("Deleting adopted legacy Ingress after annotation removal", "ingress", ing.Name)
+		if err := r.Delete(ctx, ing); err != nil && !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete adopted Ingress %s: %w", ing.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func shouldDeleteAdoptedResource(
+	resourceName string,
+	instance *ogxiov1beta1.OGXServer,
+	expectedName string,
+	annotations map[string]string,
+	obj metav1.Object,
+) bool {
+	if !metav1.IsControlledBy(obj, instance) {
+		return false
+	}
+	if _, hasAdopted := annotations[ogxiov1beta1.AdoptedFromAnnotation]; !hasAdopted {
+		return false
+	}
+	// Same-name case: the resource has the same name the kustomize pipeline
+	// would produce, so keep managing it.
+	return resourceName != expectedName
+}
+
+// --- Condition helpers for adoption ---
+
+// SetStorageAdoptedCondition sets or updates the StorageAdopted condition.
+func SetStorageAdoptedCondition(status *ogxiov1beta1.OGXServerStatus, adopted bool, message string) {
+	condition := metav1.Condition{
+		Type:               ConditionTypeStorageAdopted,
+		Status:             metav1.ConditionTrue,
+		Reason:             ReasonStorageAdopted,
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(metav1.Now().UTC()),
+	}
+	if !adopted {
+		condition.Status = metav1.ConditionFalse
+	}
+	SetCondition(status, condition)
+}
+
+// SetNetworkingAdoptedCondition sets or updates the NetworkingAdopted condition.
+func SetNetworkingAdoptedCondition(status *ogxiov1beta1.OGXServerStatus, adopted bool, message string) {
+	condition := metav1.Condition{
+		Type:               ConditionTypeNetworkingAdopted,
+		Status:             metav1.ConditionTrue,
+		Reason:             ReasonNetworkingAdopted,
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(metav1.Now().UTC()),
+	}
+	if !adopted {
+		condition.Status = metav1.ConditionFalse
+	}
+	SetCondition(status, condition)
+}
+
+// SetAdoptionConfigInvalidCondition sets the AdoptionConfigInvalid condition to True.
+func SetAdoptionConfigInvalidCondition(status *ogxiov1beta1.OGXServerStatus, message string) {
+	SetCondition(status, metav1.Condition{
+		Type:               ConditionTypeAdoptionConfigInvalid,
+		Status:             metav1.ConditionTrue,
+		Reason:             ReasonAdoptionConfigInvalid,
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(metav1.Now().UTC()),
+	})
+}
+
+// clearAdoptionConfigInvalidCondition sets AdoptionConfigInvalid to False
+// when annotations are valid, removing a previously-set warning.
+func clearAdoptionConfigInvalidCondition(status *ogxiov1beta1.OGXServerStatus) {
+	existing := GetCondition(status, ConditionTypeAdoptionConfigInvalid)
+	if existing == nil || existing.Status == metav1.ConditionFalse {
+		return
+	}
+	SetCondition(status, metav1.Condition{
+		Type:               ConditionTypeAdoptionConfigInvalid,
+		Status:             metav1.ConditionFalse,
+		Reason:             "AnnotationsValid",
+		Message:            "Adoption annotations are valid",
+		LastTransitionTime: metav1.NewTime(metav1.Now().UTC()),
+	})
+}
+
+func isExpectedLegacyOwnerRef(ownerRef *metav1.OwnerReference, legacyName string) bool {
+	if ownerRef == nil {
+		return false
+	}
+	return ownerRef.APIVersion == legacyv1alpha1.GroupVersion.String() &&
+		ownerRef.Kind == legacyv1alpha1.LlamaStackDistributionKind &&
+		ownerRef.Name == legacyName
+}

--- a/controllers/legacy_adoption.go
+++ b/controllers/legacy_adoption.go
@@ -60,7 +60,7 @@ func (r *OGXServerReconciler) adoptLegacyResources(ctx context.Context, instance
 	}
 
 	// Validate annotations before any adoption work.
-	if !validateAdoptionSources(ctx, &instance.Status, storageSource, networkingSource) {
+	if !validateAdoptionSources(ctx, &instance.Status, instance.Name, storageSource, networkingSource) {
 		return result, nil
 	}
 
@@ -85,22 +85,30 @@ func (r *OGXServerReconciler) adoptLegacyResources(ctx context.Context, instance
 func validateAdoptionSources(
 	ctx context.Context,
 	status *ogxiov1beta1.OGXServerStatus,
-	storageSource, networkingSource string,
+	instanceName, storageSource, networkingSource string,
 ) bool {
-	if !validateAdoptionSource(ctx, status, "adopt-storage", storageSource) {
+	if !validateAdoptionSource(ctx, status, "adopt-storage", storageSource, instanceName) {
 		return false
 	}
 
-	return validateAdoptionSource(ctx, status, "adopt-networking", networkingSource)
+	return validateAdoptionSource(ctx, status, "adopt-networking", networkingSource, instanceName)
 }
 
 func validateAdoptionSource(
 	ctx context.Context,
 	status *ogxiov1beta1.OGXServerStatus,
-	annotationName, value string,
+	annotationName, value, instanceName string,
 ) bool {
 	if value == "" {
 		return true
+	}
+
+	if value == instanceName {
+		logger := log.FromContext(ctx)
+		logger.Info("adoption annotation value equals CR name, rejecting", "annotation", annotationName, "value", value)
+		SetAdoptionConfigInvalidCondition(status, fmt.Sprintf(
+			"%s: value %q must not equal the CR name; same-name adoption causes resource conflicts", annotationName, value))
+		return false
 	}
 
 	if err := ogxiov1beta1.ValidateAdoptionAnnotation(value); err != nil {
@@ -368,9 +376,9 @@ func (r *OGXServerReconciler) transferOwnership(ctx context.Context, instance *o
 }
 
 // cleanupAdoptedNetworking deletes adopted legacy networking resources when the
-// adopt-networking annotation is removed and the CR name differs from the legacy
-// name (different-name case). In the same-name case, the resources have the same
-// names as what the kustomize pipeline creates, so they are managed normally.
+// adopt-networking annotation is removed. Since same-name adoption is rejected
+// at admission time, adopted resources always have different names from the
+// kustomize-created ones and must be explicitly deleted.
 func (r *OGXServerReconciler) cleanupAdoptedNetworking(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
 	// Only clean up if the annotation has been removed.
 	if instance.GetAdoptNetworkingSource() != "" {
@@ -407,7 +415,7 @@ func (r *OGXServerReconciler) cleanupAdoptedServices(ctx context.Context, instan
 
 	for i := range ownedServices.Items {
 		svc := &ownedServices.Items[i]
-		if !shouldDeleteAdoptedResource(svc.GetName(), instance, instance.Name+"-service", svc.GetAnnotations(), svc) {
+		if !shouldDeleteAdoptedResource(instance, svc.GetAnnotations(), svc) {
 			continue
 		}
 		logger.Info("Deleting adopted legacy Service after annotation removal", "service", svc.Name)
@@ -428,7 +436,7 @@ func (r *OGXServerReconciler) cleanupAdoptedIngresses(ctx context.Context, insta
 
 	for i := range ownedIngresses.Items {
 		ing := &ownedIngresses.Items[i]
-		if !shouldDeleteAdoptedResource(ing.GetName(), instance, instance.Name+IngressNameSuffix, ing.GetAnnotations(), ing) {
+		if !shouldDeleteAdoptedResource(instance, ing.GetAnnotations(), ing) {
 			continue
 		}
 		logger.Info("Deleting adopted legacy Ingress after annotation removal", "ingress", ing.Name)
@@ -441,21 +449,15 @@ func (r *OGXServerReconciler) cleanupAdoptedIngresses(ctx context.Context, insta
 }
 
 func shouldDeleteAdoptedResource(
-	resourceName string,
 	instance *ogxiov1beta1.OGXServer,
-	expectedName string,
 	annotations map[string]string,
 	obj metav1.Object,
 ) bool {
 	if !metav1.IsControlledBy(obj, instance) {
 		return false
 	}
-	if _, hasAdopted := annotations[ogxiov1beta1.AdoptedFromAnnotation]; !hasAdopted {
-		return false
-	}
-	// Same-name case: the resource has the same name the kustomize pipeline
-	// would produce, so keep managing it.
-	return resourceName != expectedName
+	_, hasAdopted := annotations[ogxiov1beta1.AdoptedFromAnnotation]
+	return hasAdopted
 }
 
 // --- Condition helpers for adoption ---

--- a/controllers/legacy_adoption_test.go
+++ b/controllers/legacy_adoption_test.go
@@ -1,0 +1,789 @@
+package controllers_test
+
+import (
+	"testing"
+
+	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestAdoptStorage(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, ns string)
+		instance func(ns string) *ogxiov1beta1.OGXServer
+		assertFn func(t *testing.T, ns string, instance *ogxiov1beta1.OGXServer)
+	}{
+		{
+			name: "happy path - adopt existing PVC",
+			setup: func(t *testing.T, ns string) {
+				t.Helper()
+				createLegacyPVC(t, ns, "my-old-llsd")
+			},
+			instance: func(ns string) *ogxiov1beta1.OGXServer {
+				return NewOGXServerBuilder().
+					WithName("my-server").
+					WithNamespace(ns).
+					WithStorage(DefaultTestStorage()).
+					WithAnnotation(ogxiov1beta1.AdoptStorageAnnotation, "my-old-llsd").
+					Build()
+			},
+			assertFn: func(t *testing.T, ns string, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+				pvc := &corev1.PersistentVolumeClaim{}
+				key := types.NamespacedName{Name: "my-old-llsd-pvc", Namespace: ns}
+				require.Eventually(t, func() bool {
+					return k8sClient.Get(t.Context(), key, pvc) == nil &&
+						metav1.IsControlledBy(pvc, instance)
+				}, testTimeout, testInterval, "PVC should be owned by new instance")
+
+				require.Equal(t, "my-old-llsd", pvc.Annotations[ogxiov1beta1.AdoptedFromAnnotation])
+				require.NotEmpty(t, pvc.Annotations[ogxiov1beta1.AdoptedAtAnnotation])
+
+				assertConditionTrue(t, instance, "StorageAdopted")
+			},
+		},
+		{
+			name:  "PVC not found - skip adoption, no error",
+			setup: func(t *testing.T, ns string) { t.Helper() },
+			instance: func(ns string) *ogxiov1beta1.OGXServer {
+				return NewOGXServerBuilder().
+					WithName("my-server").
+					WithNamespace(ns).
+					WithStorage(DefaultTestStorage()).
+					WithAnnotation(ogxiov1beta1.AdoptStorageAnnotation, "nonexistent").
+					Build()
+			},
+			assertFn: func(t *testing.T, ns string, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+				pvc := &corev1.PersistentVolumeClaim{}
+				key := types.NamespacedName{Name: "nonexistent-pvc", Namespace: ns}
+				require.True(t, apierrors.IsNotFound(k8sClient.Get(t.Context(), key, pvc)),
+					"Legacy PVC should not exist")
+			},
+		},
+		{
+			name: "idempotency - second reconcile makes no changes",
+			setup: func(t *testing.T, ns string) {
+				t.Helper()
+				createLegacyPVC(t, ns, "idempotent-llsd")
+			},
+			instance: func(ns string) *ogxiov1beta1.OGXServer {
+				return NewOGXServerBuilder().
+					WithName("my-server").
+					WithNamespace(ns).
+					WithStorage(DefaultTestStorage()).
+					WithAnnotation(ogxiov1beta1.AdoptStorageAnnotation, "idempotent-llsd").
+					Build()
+			},
+			assertFn: func(t *testing.T, ns string, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+
+				pvc := &corev1.PersistentVolumeClaim{}
+				key := types.NamespacedName{Name: "idempotent-llsd-pvc", Namespace: ns}
+				require.Eventually(t, func() bool {
+					return k8sClient.Get(t.Context(), key, pvc) == nil &&
+						metav1.IsControlledBy(pvc, instance)
+				}, testTimeout, testInterval, "PVC should be owned by new instance after first reconcile")
+
+				firstVersion := pvc.ResourceVersion
+
+				// Reconcile again.
+				ReconcileOGXServer(t, instance)
+
+				require.NoError(t, k8sClient.Get(t.Context(), key, pvc))
+				require.Equal(t, firstVersion, pvc.ResourceVersion,
+					"PVC should not change on second reconcile (idempotent)")
+			},
+		},
+		{
+			name: "old Deployment already gone - proceed to ownership transfer",
+			setup: func(t *testing.T, ns string) {
+				t.Helper()
+				createLegacyPVC(t, ns, "gone-deploy")
+			},
+			instance: func(ns string) *ogxiov1beta1.OGXServer {
+				return NewOGXServerBuilder().
+					WithName("my-server").
+					WithNamespace(ns).
+					WithStorage(DefaultTestStorage()).
+					WithAnnotation(ogxiov1beta1.AdoptStorageAnnotation, "gone-deploy").
+					Build()
+			},
+			assertFn: func(t *testing.T, ns string, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+				pvc := &corev1.PersistentVolumeClaim{}
+				key := types.NamespacedName{Name: "gone-deploy-pvc", Namespace: ns}
+				require.Eventually(t, func() bool {
+					return k8sClient.Get(t.Context(), key, pvc) == nil &&
+						metav1.IsControlledBy(pvc, instance)
+				}, testTimeout, testInterval, "PVC should be adopted even though Deployment is gone")
+			},
+		},
+		{
+			name: "old Deployment still running - scale to zero",
+			setup: func(t *testing.T, ns string) {
+				t.Helper()
+				createLegacyPVC(t, ns, "running-llsd")
+				createLegacyDeployment(t, ns, "running-llsd")
+			},
+			instance: func(ns string) *ogxiov1beta1.OGXServer {
+				return NewOGXServerBuilder().
+					WithName("my-server").
+					WithNamespace(ns).
+					WithStorage(DefaultTestStorage()).
+					WithAnnotation(ogxiov1beta1.AdoptStorageAnnotation, "running-llsd").
+					Build()
+			},
+			assertFn: func(t *testing.T, ns string, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+				// After first reconcile, old Deployment should be scaled to zero.
+				deployment := &appsv1.Deployment{}
+				key := types.NamespacedName{Name: "running-llsd", Namespace: ns}
+				require.Eventually(t, func() bool {
+					if err := k8sClient.Get(t.Context(), key, deployment); err != nil {
+						return false
+					}
+					return deployment.Spec.Replicas != nil && *deployment.Spec.Replicas == 0
+				}, testTimeout, testInterval, "Legacy Deployment should be scaled to zero")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := createTestNamespace(t, "adopt-storage")
+			tt.setup(t, namespace.Name)
+
+			instance := tt.instance(namespace.Name)
+			require.NoError(t, k8sClient.Create(t.Context(), instance))
+			t.Cleanup(func() {
+				if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+					t.Logf("Cleanup: %v", err)
+				}
+			})
+
+			ReconcileOGXServer(t, instance)
+
+			// Re-read instance for updated status.
+			require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+				Name: instance.Name, Namespace: instance.Namespace,
+			}, instance))
+
+			if tt.assertFn != nil {
+				tt.assertFn(t, namespace.Name, instance)
+			}
+		})
+	}
+}
+
+func TestAdoptNetworking(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, ns string)
+		instance func(ns string) *ogxiov1beta1.OGXServer
+		assertFn func(t *testing.T, ns string, instance *ogxiov1beta1.OGXServer)
+	}{
+		{
+			name: "adopt Service - selectors updated",
+			setup: func(t *testing.T, ns string) {
+				t.Helper()
+				createLegacyService(t, ns, "old-llsd")
+			},
+			instance: func(ns string) *ogxiov1beta1.OGXServer {
+				return NewOGXServerBuilder().
+					WithName("new-server").
+					WithNamespace(ns).
+					WithAnnotation(ogxiov1beta1.AdoptNetworkingAnnotation, "old-llsd").
+					Build()
+			},
+			assertFn: func(t *testing.T, ns string, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+				svc := &corev1.Service{}
+				key := types.NamespacedName{Name: "old-llsd-service", Namespace: ns}
+				require.Eventually(t, func() bool {
+					return k8sClient.Get(t.Context(), key, svc) == nil &&
+						metav1.IsControlledBy(svc, instance)
+				}, testTimeout, testInterval, "Service should be owned by new instance")
+
+				require.Equal(t, ogxiov1beta1.DefaultLabelValue, svc.Spec.Selector[ogxiov1beta1.DefaultLabelKey],
+					"Service selector should be updated to new label")
+				require.Equal(t, instance.Name, svc.Spec.Selector["app.kubernetes.io/instance"],
+					"Service selector should target the new instance")
+
+				require.Equal(t, "old-llsd", svc.Annotations[ogxiov1beta1.AdoptedFromAnnotation])
+				require.NotEmpty(t, svc.Annotations[ogxiov1beta1.AdoptedAtAnnotation])
+
+				assertConditionTrue(t, instance, "NetworkingAdopted")
+			},
+		},
+		{
+			name: "adopt Ingress - ownerRef transferred",
+			setup: func(t *testing.T, ns string) {
+				t.Helper()
+				createLegacyIngress(t, ns, "old-llsd")
+			},
+			instance: func(ns string) *ogxiov1beta1.OGXServer {
+				return NewOGXServerBuilder().
+					WithName("new-server").
+					WithNamespace(ns).
+					WithAnnotation(ogxiov1beta1.AdoptNetworkingAnnotation, "old-llsd").
+					Build()
+			},
+			assertFn: func(t *testing.T, ns string, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+				ingress := &networkingv1.Ingress{}
+				key := types.NamespacedName{Name: "old-llsd-ingress", Namespace: ns}
+				require.Eventually(t, func() bool {
+					return k8sClient.Get(t.Context(), key, ingress) == nil &&
+						metav1.IsControlledBy(ingress, instance)
+				}, testTimeout, testInterval, "Ingress should be owned by new instance")
+
+				require.Equal(t, "old-llsd", ingress.Annotations[ogxiov1beta1.AdoptedFromAnnotation])
+				require.NotEmpty(t, ingress.Annotations[ogxiov1beta1.AdoptedAtAnnotation])
+			},
+		},
+		{
+			name: "name mismatch - adopted and new resources coexist",
+			setup: func(t *testing.T, ns string) {
+				t.Helper()
+				createLegacyService(t, ns, "legacy-name")
+			},
+			instance: func(ns string) *ogxiov1beta1.OGXServer {
+				return NewOGXServerBuilder().
+					WithName("new-name").
+					WithNamespace(ns).
+					WithAnnotation(ogxiov1beta1.AdoptNetworkingAnnotation, "legacy-name").
+					Build()
+			},
+			assertFn: func(t *testing.T, ns string, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+				// Adopted legacy Service should exist.
+				legacySvc := &corev1.Service{}
+				legacyKey := types.NamespacedName{Name: "legacy-name-service", Namespace: ns}
+				require.Eventually(t, func() bool {
+					return k8sClient.Get(t.Context(), legacyKey, legacySvc) == nil &&
+						metav1.IsControlledBy(legacySvc, instance)
+				}, testTimeout, testInterval, "Legacy Service should be adopted")
+
+				// New Service created by kustomize pipeline should also exist.
+				newSvc := &corev1.Service{}
+				newKey := types.NamespacedName{Name: "new-name-service", Namespace: ns}
+				require.Eventually(t, func() bool {
+					return k8sClient.Get(t.Context(), newKey, newSvc) == nil
+				}, testTimeout, testInterval, "New Service should also be created by kustomize pipeline")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := createTestNamespace(t, "adopt-net")
+			tt.setup(t, namespace.Name)
+
+			instance := tt.instance(namespace.Name)
+			require.NoError(t, k8sClient.Create(t.Context(), instance))
+			t.Cleanup(func() {
+				if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+					t.Logf("Cleanup: %v", err)
+				}
+			})
+
+			ReconcileOGXServer(t, instance)
+
+			require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+				Name: instance.Name, Namespace: instance.Namespace,
+			}, instance))
+
+			if tt.assertFn != nil {
+				tt.assertFn(t, namespace.Name, instance)
+			}
+		})
+	}
+}
+
+func TestAdoptionAnnotationValidation(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	tests := []struct {
+		name           string
+		annotationKey  string
+		annotationVal  string
+		conditionCheck func(t *testing.T, instance *ogxiov1beta1.OGXServer)
+	}{
+		{
+			name:          "empty value",
+			annotationKey: ogxiov1beta1.AdoptStorageAnnotation,
+			annotationVal: "",
+			conditionCheck: func(t *testing.T, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+				// Empty annotation value means GetAdoptStorageSource() returns "",
+				// so adoption is not triggered at all. No condition should be set.
+			},
+		},
+		{
+			name:          "uppercase characters",
+			annotationKey: ogxiov1beta1.AdoptStorageAnnotation,
+			annotationVal: "MyUpperCase",
+			conditionCheck: func(t *testing.T, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+				assertConditionTrue(t, instance, "AdoptionConfigInvalid")
+			},
+		},
+		{
+			name:          "special characters",
+			annotationKey: ogxiov1beta1.AdoptStorageAnnotation,
+			annotationVal: "name_with_underscores",
+			conditionCheck: func(t *testing.T, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+				assertConditionTrue(t, instance, "AdoptionConfigInvalid")
+			},
+		},
+		{
+			name:          "too long (>63 chars)",
+			annotationKey: ogxiov1beta1.AdoptStorageAnnotation,
+			annotationVal: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			conditionCheck: func(t *testing.T, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+				assertConditionTrue(t, instance, "AdoptionConfigInvalid")
+			},
+		},
+		{
+			name:          "invalid networking annotation",
+			annotationKey: ogxiov1beta1.AdoptNetworkingAnnotation,
+			annotationVal: "INVALID",
+			conditionCheck: func(t *testing.T, instance *ogxiov1beta1.OGXServer) {
+				t.Helper()
+				assertConditionTrue(t, instance, "AdoptionConfigInvalid")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := createTestNamespace(t, "adopt-validate")
+
+			builder := NewOGXServerBuilder().
+				WithName("validation-test").
+				WithNamespace(namespace.Name)
+
+			builder = builder.WithAnnotation(tt.annotationKey, tt.annotationVal)
+
+			instance := builder.Build()
+			require.NoError(t, k8sClient.Create(t.Context(), instance))
+			t.Cleanup(func() {
+				if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+					t.Logf("Cleanup: %v", err)
+				}
+			})
+
+			ReconcileOGXServer(t, instance)
+
+			require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+				Name: instance.Name, Namespace: instance.Namespace,
+			}, instance))
+
+			tt.conditionCheck(t, instance)
+		})
+	}
+}
+
+func TestNoAdoptionWithoutAnnotations(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	namespace := createTestNamespace(t, "no-adopt")
+
+	instance := NewOGXServerBuilder().
+		WithName("clean-install").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		Build()
+
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	ReconcileOGXServer(t, instance)
+
+	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+		Name: instance.Name, Namespace: instance.Namespace,
+	}, instance))
+
+	// No adoption conditions should be set.
+	assertConditionAbsent(t, instance, "StorageAdopted")
+	assertConditionAbsent(t, instance, "NetworkingAdopted")
+	assertConditionAbsent(t, instance, "AdoptionConfigInvalid")
+
+	// Default PVC should be created with the instance name.
+	pvc := &corev1.PersistentVolumeClaim{}
+	key := types.NamespacedName{Name: "clean-install-pvc", Namespace: namespace.Name}
+	require.Eventually(t, func() bool {
+		return k8sClient.Get(t.Context(), key, pvc) == nil
+	}, testTimeout, testInterval, "Default PVC should be created for clean install")
+}
+
+func TestInvalidAdoptionStorageFallsBackToDefaultPVC(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	namespace := createTestNamespace(t, "invalid-adopt-fallback")
+
+	instance := NewOGXServerBuilder().
+		WithName("fallback-server").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		WithAnnotation(ogxiov1beta1.AdoptStorageAnnotation, "INVALID_NAME").
+		Build()
+
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	ReconcileOGXServer(t, instance)
+
+	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+		Name: instance.Name, Namespace: instance.Namespace,
+	}, instance))
+
+	assertConditionTrue(t, instance, "AdoptionConfigInvalid")
+
+	// Invalid annotation should not suppress default PVC behavior.
+	defaultPVC := &corev1.PersistentVolumeClaim{}
+	defaultKey := types.NamespacedName{Name: "fallback-server-pvc", Namespace: namespace.Name}
+	require.Eventually(t, func() bool {
+		return k8sClient.Get(t.Context(), defaultKey, defaultPVC) == nil
+	}, testTimeout, testInterval, "Default PVC should be created even when adoption annotation is invalid")
+}
+
+func TestAdoptionConfigInvalidClearsWhenAnnotationRemoved(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	namespace := createTestNamespace(t, "adopt-invalid-clear")
+
+	instance := NewOGXServerBuilder().
+		WithName("clear-invalid").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		WithAnnotation(ogxiov1beta1.AdoptStorageAnnotation, "INVALID_NAME").
+		Build()
+
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	ReconcileOGXServer(t, instance)
+	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+		Name: instance.Name, Namespace: instance.Namespace,
+	}, instance))
+	assertConditionTrue(t, instance, "AdoptionConfigInvalid")
+
+	// Remove annotation and reconcile again; invalid condition should clear.
+	delete(instance.Annotations, ogxiov1beta1.AdoptStorageAnnotation)
+	require.NoError(t, k8sClient.Update(t.Context(), instance))
+
+	ReconcileOGXServer(t, instance)
+	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+		Name: instance.Name, Namespace: instance.Namespace,
+	}, instance))
+	assertConditionFalse(t, instance, "AdoptionConfigInvalid")
+}
+
+func TestCleanupAdoptedNetworkingOnAnnotationRemoval(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	namespace := createTestNamespace(t, "adopt-cleanup-net")
+	createLegacyService(t, namespace.Name, "legacy-net")
+
+	instance := NewOGXServerBuilder().
+		WithName("new-net").
+		WithNamespace(namespace.Name).
+		WithAnnotation(ogxiov1beta1.AdoptNetworkingAnnotation, "legacy-net").
+		Build()
+
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	// First reconcile adopts the legacy service.
+	ReconcileOGXServer(t, instance)
+	legacyKey := types.NamespacedName{Name: "legacy-net-service", Namespace: namespace.Name}
+	legacySvc := &corev1.Service{}
+	require.Eventually(t, func() bool {
+		return k8sClient.Get(t.Context(), legacyKey, legacySvc) == nil &&
+			metav1.IsControlledBy(legacySvc, instance)
+	}, testTimeout, testInterval, "Legacy Service should be adopted")
+
+	// Remove annotation and reconcile again; adopted legacy service should be deleted.
+	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+		Name: instance.Name, Namespace: instance.Namespace,
+	}, instance))
+	delete(instance.Annotations, ogxiov1beta1.AdoptNetworkingAnnotation)
+	require.NoError(t, k8sClient.Update(t.Context(), instance))
+
+	ReconcileOGXServer(t, instance)
+	require.Eventually(t, func() bool {
+		return apierrors.IsNotFound(k8sClient.Get(t.Context(), legacyKey, &corev1.Service{}))
+	}, testTimeout, testInterval, "Adopted legacy Service should be deleted when annotation is removed")
+
+	// New service for current instance should exist.
+	newKey := types.NamespacedName{Name: "new-net-service", Namespace: namespace.Name}
+	require.Eventually(t, func() bool {
+		return k8sClient.Get(t.Context(), newKey, &corev1.Service{}) == nil
+	}, testTimeout, testInterval, "Current instance Service should exist after cleanup")
+}
+
+func TestAdoptionRejectsUnexpectedControllerOwner(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	namespace := createTestNamespace(t, "adopt-owner-guard")
+	createLegacyPVCWithControllerOwner(t, namespace.Name, "legacy-safe", metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+		Name:       "not-legacy-safe",
+		UID:        types.UID("foreign-owner"),
+		Controller: boolPtrAdoptionTest(true),
+	})
+
+	instance := NewOGXServerBuilder().
+		WithName("owner-check").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		WithAnnotation(ogxiov1beta1.AdoptStorageAnnotation, "legacy-safe").
+		Build()
+
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	reconciler := createTestReconciler()
+	_, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to adopt")
+}
+
+// --- Helpers ---
+
+func (b *OGXServerBuilder) WithAnnotation(key, value string) *OGXServerBuilder {
+	if b.instance.Annotations == nil {
+		b.instance.Annotations = make(map[string]string)
+	}
+	b.instance.Annotations[key] = value
+	return b
+}
+
+func createLegacyPVC(t *testing.T, ns, legacyName string) {
+	t.Helper()
+	storageSize := resource.MustParse("1Gi")
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      legacyName + "-pvc",
+			Namespace: ns,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: storageSize,
+				},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(t.Context(), pvc))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), pvc); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup PVC: %v", err)
+		}
+	})
+}
+
+func createLegacyPVCWithControllerOwner(t *testing.T, ns, legacyName string, ownerRef metav1.OwnerReference) {
+	t.Helper()
+	storageSize := resource.MustParse("1Gi")
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            legacyName + "-pvc",
+			Namespace:       ns,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: storageSize,
+				},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(t.Context(), pvc))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), pvc); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup PVC: %v", err)
+		}
+	})
+}
+
+func createLegacyDeployment(t *testing.T, ns, legacyName string) {
+	t.Helper()
+	replicas := int32(1)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      legacyName,
+			Namespace: ns,
+			Labels:    map[string]string{"app.kubernetes.io/instance": legacyName},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app.kubernetes.io/instance": legacyName},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app.kubernetes.io/instance": legacyName},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "llama-stack",
+						Image: "registry.example.com/llama-stack:latest",
+					}},
+				},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(t.Context(), deployment))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), deployment); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup Deployment: %v", err)
+		}
+	})
+}
+
+func createLegacyService(t *testing.T, ns, legacyName string) {
+	t.Helper()
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      legacyName + "-service",
+			Namespace: ns,
+			Labels:    map[string]string{"app": "llama-stack"},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app":                        "llama-stack",
+				"app.kubernetes.io/instance": legacyName,
+			},
+			Ports: []corev1.ServicePort{{
+				Name:     "http",
+				Port:     8321,
+				Protocol: corev1.ProtocolTCP,
+			}},
+		},
+	}
+	require.NoError(t, k8sClient.Create(t.Context(), svc))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), svc); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup Service: %v", err)
+		}
+	})
+}
+
+func createLegacyIngress(t *testing.T, ns, legacyName string) {
+	t.Helper()
+	pathType := networkingv1.PathTypePrefix
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      legacyName + "-ingress",
+			Namespace: ns,
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{{
+				Host: "legacy.example.com",
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Path:     "/",
+							PathType: &pathType,
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: legacyName + "-service",
+									Port: networkingv1.ServiceBackendPort{
+										Number: 8321,
+									},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+	require.NoError(t, k8sClient.Create(t.Context(), ingress))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), ingress); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup Ingress: %v", err)
+		}
+	})
+}
+
+func assertConditionTrue(t *testing.T, instance *ogxiov1beta1.OGXServer, condType string) {
+	t.Helper()
+	for _, c := range instance.Status.Conditions {
+		if c.Type == condType {
+			require.Equal(t, metav1.ConditionTrue, c.Status,
+				"condition %s should be True", condType)
+			return
+		}
+	}
+	t.Errorf("condition %s not found", condType)
+}
+
+func assertConditionAbsent(t *testing.T, instance *ogxiov1beta1.OGXServer, condType string) {
+	t.Helper()
+	for _, c := range instance.Status.Conditions {
+		if c.Type == condType {
+			t.Errorf("condition %s should not be present", condType)
+			return
+		}
+	}
+}
+
+func assertConditionFalse(t *testing.T, instance *ogxiov1beta1.OGXServer, condType string) {
+	t.Helper()
+	for _, c := range instance.Status.Conditions {
+		if c.Type == condType {
+			require.Equal(t, metav1.ConditionFalse, c.Status,
+				"condition %s should be False", condType)
+			return
+		}
+	}
+	t.Errorf("condition %s not found", condType)
+}
+
+func boolPtrAdoptionTest(v bool) *bool {
+	return &v
+}

--- a/controllers/legacy_adoption_test.go
+++ b/controllers/legacy_adoption_test.go
@@ -552,6 +552,33 @@ func TestCleanupAdoptedNetworkingOnAnnotationRemoval(t *testing.T) {
 	}, testTimeout, testInterval, "Current instance Service should exist after cleanup")
 }
 
+func TestSelfAdoptionRejectedByController(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	namespace := createTestNamespace(t, "self-adopt")
+
+	instance := NewOGXServerBuilder().
+		WithName("same-name").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		WithAnnotation(ogxiov1beta1.AdoptStorageAnnotation, "same-name").
+		Build()
+
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	ReconcileOGXServer(t, instance)
+
+	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+		Name: instance.Name, Namespace: instance.Namespace,
+	}, instance))
+
+	assertConditionTrue(t, instance, "AdoptionConfigInvalid")
+}
+
 func TestAdoptionRejectsUnexpectedControllerOwner(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 	namespace := createTestNamespace(t, "adopt-owner-guard")

--- a/controllers/legacy_adoption_test.go
+++ b/controllers/legacy_adoption_test.go
@@ -45,10 +45,11 @@ func TestAdoptStorage(t *testing.T) {
 				key := types.NamespacedName{Name: "my-old-llsd-pvc", Namespace: ns}
 				require.Eventually(t, func() bool {
 					return k8sClient.Get(t.Context(), key, pvc) == nil &&
-						metav1.IsControlledBy(pvc, instance)
-				}, testTimeout, testInterval, "PVC should be owned by new instance")
+						pvc.Labels[ogxiov1beta1.AdoptedFromLabel] == "my-old-llsd"
+				}, testTimeout, testInterval, "PVC should have adopted-from label")
 
-				require.Equal(t, "my-old-llsd", pvc.Annotations[ogxiov1beta1.AdoptedFromAnnotation])
+				require.Nil(t, metav1.GetControllerOf(pvc),
+					"Adopted PVC should not have a controller ownerRef")
 				require.NotEmpty(t, pvc.Annotations[ogxiov1beta1.AdoptedAtAnnotation])
 
 				assertConditionTrue(t, instance, "StorageAdopted")
@@ -94,8 +95,8 @@ func TestAdoptStorage(t *testing.T) {
 				key := types.NamespacedName{Name: "idempotent-llsd-pvc", Namespace: ns}
 				require.Eventually(t, func() bool {
 					return k8sClient.Get(t.Context(), key, pvc) == nil &&
-						metav1.IsControlledBy(pvc, instance)
-				}, testTimeout, testInterval, "PVC should be owned by new instance after first reconcile")
+						pvc.Labels[ogxiov1beta1.AdoptedFromLabel] == "idempotent-llsd"
+				}, testTimeout, testInterval, "PVC should have adopted-from label after first reconcile")
 
 				firstVersion := pvc.ResourceVersion
 
@@ -108,7 +109,7 @@ func TestAdoptStorage(t *testing.T) {
 			},
 		},
 		{
-			name: "old Deployment already gone - proceed to ownership transfer",
+			name: "old Deployment already gone - proceed to adoption",
 			setup: func(t *testing.T, ns string) {
 				t.Helper()
 				createLegacyPVC(t, ns, "gone-deploy")
@@ -127,8 +128,11 @@ func TestAdoptStorage(t *testing.T) {
 				key := types.NamespacedName{Name: "gone-deploy-pvc", Namespace: ns}
 				require.Eventually(t, func() bool {
 					return k8sClient.Get(t.Context(), key, pvc) == nil &&
-						metav1.IsControlledBy(pvc, instance)
+						pvc.Labels[ogxiov1beta1.AdoptedFromLabel] == "gone-deploy"
 				}, testTimeout, testInterval, "PVC should be adopted even though Deployment is gone")
+
+				require.Nil(t, metav1.GetControllerOf(pvc),
+					"Adopted PVC should not have a controller ownerRef")
 			},
 		},
 		{
@@ -577,6 +581,55 @@ func TestSelfAdoptionRejectedByController(t *testing.T) {
 	}, instance))
 
 	assertConditionTrue(t, instance, "AdoptionConfigInvalid")
+}
+
+func TestAdoptedPVCDiscoveredByLabelAfterAnnotationRemoval(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	namespace := createTestNamespace(t, "adopt-pvc-label-disc")
+	createLegacyPVC(t, namespace.Name, "disc-legacy")
+
+	instance := NewOGXServerBuilder().
+		WithName("disc-server").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		WithAnnotation(ogxiov1beta1.AdoptStorageAnnotation, "disc-legacy").
+		Build()
+
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	// First reconcile adopts the PVC (sets label, strips old ownerRef).
+	ReconcileOGXServer(t, instance)
+	pvc := &corev1.PersistentVolumeClaim{}
+	pvcKey := types.NamespacedName{Name: "disc-legacy-pvc", Namespace: namespace.Name}
+	require.Eventually(t, func() bool {
+		return k8sClient.Get(t.Context(), pvcKey, pvc) == nil &&
+			pvc.Labels[ogxiov1beta1.AdoptedFromLabel] == "disc-legacy"
+	}, testTimeout, testInterval, "PVC should be adopted with label")
+
+	// Remove the annotation and reconcile again.
+	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+		Name: instance.Name, Namespace: instance.Namespace,
+	}, instance))
+	delete(instance.Annotations, ogxiov1beta1.AdoptStorageAnnotation)
+	require.NoError(t, k8sClient.Update(t.Context(), instance))
+
+	ReconcileOGXServer(t, instance)
+
+	// The adopted PVC should still exist (not garbage collected).
+	require.NoError(t, k8sClient.Get(t.Context(), pvcKey, pvc),
+		"Adopted PVC must survive annotation removal")
+
+	// No new default PVC should be created — the controller should discover
+	// the adopted PVC by label and keep using it.
+	defaultPVC := &corev1.PersistentVolumeClaim{}
+	defaultKey := types.NamespacedName{Name: "disc-server-pvc", Namespace: namespace.Name}
+	require.True(t, apierrors.IsNotFound(k8sClient.Get(t.Context(), defaultKey, defaultPVC)),
+		"Default PVC should NOT be created when adopted PVC is discovered by label")
 }
 
 func TestAdoptionRejectsUnexpectedControllerOwner(t *testing.T) {

--- a/controllers/legacy_adoption_test.go
+++ b/controllers/legacy_adoption_test.go
@@ -228,7 +228,7 @@ func TestAdoptNetworking(t *testing.T) {
 				require.Equal(t, instance.Name, svc.Spec.Selector["app.kubernetes.io/instance"],
 					"Service selector should target the new instance")
 
-				require.Equal(t, "old-llsd", svc.Annotations[ogxiov1beta1.AdoptedFromAnnotation])
+				require.Equal(t, "old-llsd", svc.Labels[ogxiov1beta1.AdoptedFromLabel])
 				require.NotEmpty(t, svc.Annotations[ogxiov1beta1.AdoptedAtAnnotation])
 
 				assertConditionTrue(t, instance, "NetworkingAdopted")
@@ -256,7 +256,7 @@ func TestAdoptNetworking(t *testing.T) {
 						metav1.IsControlledBy(ingress, instance)
 				}, testTimeout, testInterval, "Ingress should be owned by new instance")
 
-				require.Equal(t, "old-llsd", ingress.Annotations[ogxiov1beta1.AdoptedFromAnnotation])
+				require.Equal(t, "old-llsd", ingress.Labels[ogxiov1beta1.AdoptedFromLabel])
 				require.NotEmpty(t, ingress.Annotations[ogxiov1beta1.AdoptedAtAnnotation])
 			},
 		},
@@ -583,10 +583,15 @@ func TestSelfAdoptionRejectedByController(t *testing.T) {
 	assertConditionTrue(t, instance, "AdoptionConfigInvalid")
 }
 
-func TestAdoptedPVCDiscoveredByLabelAfterAnnotationRemoval(t *testing.T) {
+func TestAdoptedPVCLifecycle(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
-	namespace := createTestNamespace(t, "adopt-pvc-label-disc")
+	namespace := createTestNamespace(t, "adopt-pvc-lifecycle")
 	createLegacyPVC(t, namespace.Name, "disc-legacy")
+
+	// --- arrange ---
+	pvcKey := types.NamespacedName{Name: "disc-legacy-pvc", Namespace: namespace.Name}
+	defaultKey := types.NamespacedName{Name: "disc-server-pvc", Namespace: namespace.Name}
+	deployKey := types.NamespacedName{Name: "disc-server", Namespace: namespace.Name}
 
 	instance := NewOGXServerBuilder().
 		WithName("disc-server").
@@ -596,22 +601,19 @@ func TestAdoptedPVCDiscoveredByLabelAfterAnnotationRemoval(t *testing.T) {
 		Build()
 
 	require.NoError(t, k8sClient.Create(t.Context(), instance))
-	t.Cleanup(func() {
-		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
-			t.Logf("Cleanup: %v", err)
-		}
-	})
 
-	// First reconcile adopts the PVC (sets label, strips old ownerRef).
+	// --- act: adopt PVC, then remove annotation ---
 	ReconcileOGXServer(t, instance)
+
 	pvc := &corev1.PersistentVolumeClaim{}
-	pvcKey := types.NamespacedName{Name: "disc-legacy-pvc", Namespace: namespace.Name}
 	require.Eventually(t, func() bool {
 		return k8sClient.Get(t.Context(), pvcKey, pvc) == nil &&
 			pvc.Labels[ogxiov1beta1.AdoptedFromLabel] == "disc-legacy"
 	}, testTimeout, testInterval, "PVC should be adopted with label")
 
-	// Remove the annotation and reconcile again.
+	deployment := &appsv1.Deployment{}
+	waitForResource(t, k8sClient, namespace.Name, "disc-server", deployment)
+
 	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
 		Name: instance.Name, Namespace: instance.Namespace,
 	}, instance))
@@ -620,16 +622,55 @@ func TestAdoptedPVCDiscoveredByLabelAfterAnnotationRemoval(t *testing.T) {
 
 	ReconcileOGXServer(t, instance)
 
-	// The adopted PVC should still exist (not garbage collected).
+	// --- assert: adopted PVC discovered by label, Deployment uses it ---
 	require.NoError(t, k8sClient.Get(t.Context(), pvcKey, pvc),
 		"Adopted PVC must survive annotation removal")
-
-	// No new default PVC should be created — the controller should discover
-	// the adopted PVC by label and keep using it.
-	defaultPVC := &corev1.PersistentVolumeClaim{}
-	defaultKey := types.NamespacedName{Name: "disc-server-pvc", Namespace: namespace.Name}
-	require.True(t, apierrors.IsNotFound(k8sClient.Get(t.Context(), defaultKey, defaultPVC)),
+	require.True(t, apierrors.IsNotFound(k8sClient.Get(t.Context(), defaultKey, &corev1.PersistentVolumeClaim{})),
 		"Default PVC should NOT be created when adopted PVC is discovered by label")
+
+	require.NoError(t, k8sClient.Get(t.Context(), deployKey, deployment))
+	AssertDeploymentUsesPVCStorage(t, deployment, "disc-legacy-pvc")
+
+	// --- act: delete OGXServer ---
+	require.NoError(t, k8sClient.Delete(t.Context(), instance))
+	require.Eventually(t, func() bool {
+		return apierrors.IsNotFound(k8sClient.Get(t.Context(), types.NamespacedName{
+			Name: "disc-server", Namespace: namespace.Name,
+		}, &ogxiov1beta1.OGXServer{}))
+	}, testTimeout, testInterval, "OGXServer should be deleted")
+
+	// --- assert: adopted PVC survives CR deletion with labels intact ---
+	require.NoError(t, k8sClient.Get(t.Context(), pvcKey, pvc),
+		"Adopted PVC must survive OGXServer deletion")
+	require.Equal(t, "disc-legacy", pvc.Labels[ogxiov1beta1.AdoptedFromLabel],
+		"Adopted-from label must be unchanged after CR deletion")
+	require.Equal(t, "disc-server", pvc.Labels["app.kubernetes.io/instance"],
+		"Instance label must be unchanged after CR deletion")
+
+	// --- act: recreate OGXServer with same name ---
+	instance = NewOGXServerBuilder().
+		WithName("disc-server").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		Build()
+
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	ReconcileOGXServer(t, instance)
+
+	// --- assert: adopted PVC discovered, no default PVC created ---
+	require.NoError(t, k8sClient.Get(t.Context(), pvcKey, pvc),
+		"Adopted PVC must still exist after recreate")
+	require.True(t, apierrors.IsNotFound(k8sClient.Get(t.Context(), defaultKey, &corev1.PersistentVolumeClaim{})),
+		"Default PVC should NOT be created when adopted PVC is discovered by label")
+
+	require.NoError(t, k8sClient.Get(t.Context(), deployKey, deployment))
+	AssertDeploymentUsesPVCStorage(t, deployment, "disc-legacy-pvc")
 }
 
 func TestAdoptionRejectsUnexpectedControllerOwner(t *testing.T) {
@@ -666,6 +707,71 @@ func TestAdoptionRejectsUnexpectedControllerOwner(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to adopt")
+}
+
+func TestMultipleAdoptedPVCsReturnsTerminalError(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	namespace := createTestNamespace(t, "adopt-multi-pvc")
+
+	// --- arrange: create two PVCs with matching adoption labels ---
+	for _, pvcName := range []string{"first-pvc", "second-pvc"} {
+		storageSize := resource.MustParse("1Gi")
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvcName,
+				Namespace: namespace.Name,
+				Labels: map[string]string{
+					ogxiov1beta1.AdoptedFromLabel: "some-legacy",
+					"app.kubernetes.io/instance":  "multi-test",
+				},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: storageSize,
+					},
+				},
+			},
+		}
+		require.NoError(t, k8sClient.Create(t.Context(), pvc))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(t.Context(), pvc); err != nil && !apierrors.IsNotFound(err) {
+				t.Logf("Cleanup PVC: %v", err)
+			}
+		})
+	}
+
+	instance := NewOGXServerBuilder().
+		WithName("multi-test").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		Build()
+
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	// --- act ---
+	reconciler := createTestReconciler()
+	result, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		},
+	})
+
+	// --- assert: no error returned (terminal), no requeue ---
+	require.NoError(t, err, "terminal error should not propagate as a reconcile error")
+	require.Zero(t, result.RequeueAfter, "should not requeue on terminal error")
+
+	require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{
+		Name: instance.Name, Namespace: instance.Namespace,
+	}, instance))
+	assertConditionTrue(t, instance, "AdoptionConfigInvalid")
 }
 
 // --- Helpers ---

--- a/controllers/ogxserver_controller.go
+++ b/controllers/ogxserver_controller.go
@@ -111,7 +111,9 @@ type OGXServerReconciler struct {
 
 // hasOverrideConfig checks if the instance references an override ConfigMap.
 func (r *OGXServerReconciler) hasOverrideConfig(instance *ogxiov1beta1.OGXServer) bool {
-	return instance.Spec.OverrideConfig != nil && instance.Spec.OverrideConfig.Name != ""
+	return instance.Spec.OverrideConfig != nil &&
+		instance.Spec.OverrideConfig.Name != "" &&
+		instance.Spec.OverrideConfig.Key != ""
 }
 
 // hasCACertificates checks if the instance has TLS trust CA certificates configured.
@@ -154,6 +156,15 @@ func (r *OGXServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Reconcile all resources, storing the error for later.
 	reconcileErr := r.reconcileResources(ctx, instance)
+
+	// Handle adoption requeue: not a real error, just needs a delayed retry.
+	var requeueErr *requeueError
+	if errors.As(reconcileErr, &requeueErr) {
+		if statusUpdateErr := r.updateStatus(ctx, instance, nil); statusUpdateErr != nil {
+			logger.Error(statusUpdateErr, "failed to update status during adoption requeue")
+		}
+		return ctrl.Result{RequeueAfter: requeueErr.after}, nil
+	}
 
 	// Update the status, passing in any reconciliation error.
 	if statusUpdateErr := r.updateStatus(ctx, instance, reconcileErr); statusUpdateErr != nil {
@@ -231,12 +242,16 @@ func (r *OGXServerReconciler) fetchInstance(ctx context.Context, namespacedName 
 }
 
 // determineKindsToExclude returns a list of resource kinds that should be excluded
-// based on the instance specification.
+// based on the instance specification and adoption annotations.
 func (r *OGXServerReconciler) determineKindsToExclude(instance *ogxiov1beta1.OGXServer) []string {
 	var kinds []string
 
-	if instance.Spec.Workload == nil || instance.Spec.Workload.Storage == nil {
+	if shouldExcludePVC(instance) {
 		kinds = append(kinds, "PersistentVolumeClaim")
+	}
+
+	if shouldExcludeServiceForAdoption(instance) {
+		kinds = append(kinds, "Service")
 	}
 
 	// Per-CR NetworkPolicy toggle (default: enabled)
@@ -245,7 +260,6 @@ func (r *OGXServerReconciler) determineKindsToExclude(instance *ogxiov1beta1.OGX
 		kinds = append(kinds, "NetworkPolicy")
 	}
 
-	// Service is always created in v1beta1 (port always exists via defaults)
 	if !needsPodDisruptionBudget(instance) {
 		kinds = append(kinds, "PodDisruptionBudget")
 	}
@@ -255,6 +269,29 @@ func (r *OGXServerReconciler) determineKindsToExclude(instance *ogxiov1beta1.OGX
 	}
 
 	return kinds
+}
+
+func shouldExcludePVC(instance *ogxiov1beta1.OGXServer) bool {
+	// When a valid adopt-storage annotation is present, suppress PVC creation from
+	// the kustomize pipeline to avoid a duplicate empty PVC alongside the adopted one.
+	storageSource := instance.GetAdoptStorageSource()
+	if storageSource != "" && ogxiov1beta1.ValidateAdoptionAnnotation(storageSource) == nil {
+		return true
+	}
+
+	return instance.Spec.Workload == nil || instance.Spec.Workload.Storage == nil
+}
+
+func shouldExcludeServiceForAdoption(instance *ogxiov1beta1.OGXServer) bool {
+	// When a valid adopt-networking annotation is present and the CR name matches
+	// the legacy name, exclude Service from the kustomize pipeline because the
+	// adopted Service already has the correct name. When names differ, allow
+	// the pipeline to create a new Service alongside the adopted one.
+	legacyNet := instance.GetAdoptNetworkingSource()
+	if legacyNet == "" || ogxiov1beta1.ValidateAdoptionAnnotation(legacyNet) != nil {
+		return false
+	}
+	return legacyNet == instance.Name
 }
 
 // reconcileAllManifestResources applies all manifest-based resources using kustomize.
@@ -456,6 +493,16 @@ func (r *OGXServerReconciler) buildManifestContext(ctx context.Context, instance
 
 // reconcileResources reconciles all resources for the OGXServer instance.
 func (r *OGXServerReconciler) reconcileResources(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
+	// Run adoption logic before manifest reconciliation so that adopted
+	// resources are available for the kustomize pipeline to reference.
+	adoptResult, err := r.adoptLegacyResources(ctx, instance)
+	if err != nil {
+		return fmt.Errorf("failed to adopt legacy resources: %w", err)
+	}
+	if adoptResult.requeue {
+		return &requeueError{after: adoptResult.requeueAfter}
+	}
+
 	// Reconcile ConfigMaps first
 	if err := r.reconcileConfigMaps(ctx, instance); err != nil {
 		return err
@@ -472,7 +519,24 @@ func (r *OGXServerReconciler) reconcileResources(ctx context.Context, instance *
 		return fmt.Errorf("failed to reconcile Ingress: %w", err)
 	}
 
+	// Clean up adopted networking resources if the annotation was removed.
+	// This runs after normal networking reconciliation to avoid delete-before-create
+	// gaps during the migration-off path.
+	if err := r.cleanupAdoptedNetworking(ctx, instance); err != nil {
+		return fmt.Errorf("failed to clean up adopted networking: %w", err)
+	}
+
 	return nil
+}
+
+// requeueError signals that the reconciler should requeue after a delay
+// without reporting an error to the controller runtime.
+type requeueError struct {
+	after time.Duration
+}
+
+func (e *requeueError) Error() string {
+	return fmt.Sprintf("requeue after %s", e.after)
 }
 
 func (r *OGXServerReconciler) reconcileConfigMaps(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
@@ -601,9 +665,15 @@ func (r *OGXServerReconciler) mapConfigMapToReconcileRequests(ctx context.Contex
 		return nil
 	}
 
-	// List all OGXServer CRs to find which ones reference this ConfigMap.
+	// List relevant OGXServer CRs to find which ones reference this ConfigMap.
+	// User ConfigMaps are namespace-scoped per 003 design, so default to same-namespace
+	// listing. Keep operator config global since it can affect all instances.
 	var instances ogxiov1beta1.OGXServerList
-	if err := r.List(ctx, &instances); err != nil {
+	listOpts := []client.ListOption{client.InNamespace(configMap.Namespace)}
+	if configMap.Name == operatorConfigData {
+		listOpts = nil
+	}
+	if err := r.List(ctx, &instances, listOpts...); err != nil {
 		logger.Error(err, "failed to list OGXServer instances for ConfigMap mapping")
 		return nil
 	}
@@ -932,6 +1002,7 @@ func (r *OGXServerReconciler) reconcileOverrideConfigMap(ctx context.Context, in
 
 	logger.V(1).Info("Validating referenced override ConfigMap exists",
 		"configMapName", instance.Spec.OverrideConfig.Name,
+		"configMapKey", instance.Spec.OverrideConfig.Key,
 		"configMapNamespace", configMapNamespace)
 
 	// Read via direct client — user ConfigMaps lack operator labels
@@ -949,10 +1020,19 @@ func (r *OGXServerReconciler) reconcileOverrideConfigMap(ctx context.Context, in
 		}
 		return fmt.Errorf("failed to fetch ConfigMap %s/%s: %w", configMapNamespace, instance.Spec.OverrideConfig.Name, err)
 	}
+	if _, exists := configMap.Data[instance.Spec.OverrideConfig.Key]; !exists {
+		return fmt.Errorf(
+			"failed to find override ConfigMap key '%s' in ConfigMap %s/%s",
+			instance.Spec.OverrideConfig.Key,
+			configMapNamespace,
+			instance.Spec.OverrideConfig.Name,
+		)
+	}
 
 	logger.V(1).Info("Override ConfigMap found and validated",
 		"configMap", configMap.Name,
 		"namespace", configMap.Namespace,
+		"key", instance.Spec.OverrideConfig.Key,
 		"dataKeys", len(configMap.Data))
 	return nil
 }

--- a/controllers/ogxserver_controller.go
+++ b/controllers/ogxserver_controller.go
@@ -250,10 +250,6 @@ func (r *OGXServerReconciler) determineKindsToExclude(instance *ogxiov1beta1.OGX
 		kinds = append(kinds, "PersistentVolumeClaim")
 	}
 
-	if shouldExcludeServiceForAdoption(instance) {
-		kinds = append(kinds, "Service")
-	}
-
 	// Per-CR NetworkPolicy toggle (default: enabled)
 	if instance.Spec.Network != nil && instance.Spec.Network.Policy != nil &&
 		instance.Spec.Network.Policy.Enabled != nil && !*instance.Spec.Network.Policy.Enabled {
@@ -280,18 +276,6 @@ func shouldExcludePVC(instance *ogxiov1beta1.OGXServer) bool {
 	}
 
 	return instance.Spec.Workload == nil || instance.Spec.Workload.Storage == nil
-}
-
-func shouldExcludeServiceForAdoption(instance *ogxiov1beta1.OGXServer) bool {
-	// When a valid adopt-networking annotation is present and the CR name matches
-	// the legacy name, exclude Service from the kustomize pipeline because the
-	// adopted Service already has the correct name. When names differ, allow
-	// the pipeline to create a new Service alongside the adopted one.
-	legacyNet := instance.GetAdoptNetworkingSource()
-	if legacyNet == "" || ogxiov1beta1.ValidateAdoptionAnnotation(legacyNet) != nil {
-		return false
-	}
-	return legacyNet == instance.Name
 }
 
 // reconcileAllManifestResources applies all manifest-based resources using kustomize.

--- a/controllers/ogxserver_controller.go
+++ b/controllers/ogxserver_controller.go
@@ -243,10 +243,10 @@ func (r *OGXServerReconciler) fetchInstance(ctx context.Context, namespacedName 
 
 // determineKindsToExclude returns a list of resource kinds that should be excluded
 // based on the instance specification and adoption annotations.
-func (r *OGXServerReconciler) determineKindsToExclude(instance *ogxiov1beta1.OGXServer) []string {
+func (r *OGXServerReconciler) determineKindsToExclude(instance *ogxiov1beta1.OGXServer, effectivePVCName string) []string {
 	var kinds []string
 
-	if shouldExcludePVC(instance) {
+	if shouldExcludePVC(instance, effectivePVCName) {
 		kinds = append(kinds, "PersistentVolumeClaim")
 	}
 
@@ -267,11 +267,10 @@ func (r *OGXServerReconciler) determineKindsToExclude(instance *ogxiov1beta1.OGX
 	return kinds
 }
 
-func shouldExcludePVC(instance *ogxiov1beta1.OGXServer) bool {
-	// When a valid adopt-storage annotation is present, suppress PVC creation from
-	// the kustomize pipeline to avoid a duplicate empty PVC alongside the adopted one.
-	storageSource := instance.GetAdoptStorageSource()
-	if storageSource != "" && ogxiov1beta1.ValidateAdoptionAnnotation(storageSource) == nil {
+func shouldExcludePVC(instance *ogxiov1beta1.OGXServer, effectivePVCName string) bool {
+	// Suppress PVC creation when the deployment is using an adopted PVC
+	// (either via annotation or discovered by label after annotation removal).
+	if effectivePVCName != instance.Name+"-pvc" {
 		return true
 	}
 
@@ -280,8 +279,14 @@ func shouldExcludePVC(instance *ogxiov1beta1.OGXServer) bool {
 
 // reconcileAllManifestResources applies all manifest-based resources using kustomize.
 func (r *OGXServerReconciler) reconcileAllManifestResources(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
+	// Resolve the PVC name once — may use annotation or label-based discovery.
+	effectivePVCName, err := r.resolveEffectivePVCName(ctx, instance)
+	if err != nil {
+		return fmt.Errorf("failed to resolve effective PVC name: %w", err)
+	}
+
 	// Build manifest context for Deployment
-	manifestCtx, err := r.buildManifestContext(ctx, instance)
+	manifestCtx, err := r.buildManifestContext(ctx, instance, effectivePVCName)
 	if err != nil {
 		return fmt.Errorf("failed to build manifest context: %w", err)
 	}
@@ -292,7 +297,7 @@ func (r *OGXServerReconciler) reconcileAllManifestResources(ctx context.Context,
 		return fmt.Errorf("failed to render manifests: %w", err)
 	}
 
-	kindsToExclude := r.determineKindsToExclude(instance)
+	kindsToExclude := r.determineKindsToExclude(instance, effectivePVCName)
 	filteredResMap, err := deploy.FilterExcludeKinds(resMap, kindsToExclude)
 	if err != nil {
 		return fmt.Errorf("failed to filter manifests: %w", err)
@@ -425,7 +430,7 @@ func (r *OGXServerReconciler) deleteHorizontalPodAutoscalerIfExists(ctx context.
 }
 
 // buildManifestContext creates the manifest context for Deployment using existing helper functions.
-func (r *OGXServerReconciler) buildManifestContext(ctx context.Context, instance *ogxiov1beta1.OGXServer) (*deploy.ManifestContext, error) {
+func (r *OGXServerReconciler) buildManifestContext(ctx context.Context, instance *ogxiov1beta1.OGXServer, effectivePVCName string) (*deploy.ManifestContext, error) {
 	// Validate distribution configuration
 	if err := r.validateDistribution(instance); err != nil {
 		return nil, err
@@ -437,7 +442,7 @@ func (r *OGXServerReconciler) buildManifestContext(ctx context.Context, instance
 	}
 
 	container := buildContainerSpec(ctx, r, instance, resolvedImage)
-	podSpec := configurePodStorage(ctx, r, instance, container)
+	podSpec := configurePodStorage(ctx, r, instance, container, effectivePVCName)
 
 	// Get override ConfigMap hash if needed
 	var configMapHash string
@@ -927,9 +932,15 @@ func (r *OGXServerReconciler) updateStorageStatus(ctx context.Context, instance 
 	if instance.Spec.Workload == nil || instance.Spec.Workload.Storage == nil {
 		return
 	}
-	pvc := &corev1.PersistentVolumeClaim{}
-	err := r.Get(ctx, types.NamespacedName{Name: instance.GetEffectivePVCName(), Namespace: instance.Namespace}, pvc)
+
+	pvcName, err := r.resolveEffectivePVCName(ctx, instance)
 	if err != nil {
+		SetStorageReadyCondition(&instance.Status, false, fmt.Sprintf("Failed to resolve PVC name: %v", err))
+		return
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: instance.Namespace}, pvc); err != nil {
 		SetStorageReadyCondition(&instance.Status, false, fmt.Sprintf("Failed to get PVC: %v", err))
 		return
 	}

--- a/controllers/ogxserver_controller.go
+++ b/controllers/ogxserver_controller.go
@@ -157,13 +157,8 @@ func (r *OGXServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Reconcile all resources, storing the error for later.
 	reconcileErr := r.reconcileResources(ctx, instance)
 
-	// Handle adoption requeue: not a real error, just needs a delayed retry.
-	var requeueErr *requeueError
-	if errors.As(reconcileErr, &requeueErr) {
-		if statusUpdateErr := r.updateStatus(ctx, instance, nil); statusUpdateErr != nil {
-			logger.Error(statusUpdateErr, "failed to update status during adoption requeue")
-		}
-		return ctrl.Result{RequeueAfter: requeueErr.after}, nil
+	if result, done := r.handleSentinelErrors(ctx, instance, reconcileErr); done {
+		return result, nil
 	}
 
 	// Update the status, passing in any reconciliation error.
@@ -526,6 +521,40 @@ type requeueError struct {
 
 func (e *requeueError) Error() string {
 	return fmt.Sprintf("requeue after %s", e.after)
+}
+
+// terminalError signals a problem that cannot be resolved by retrying.
+// The reconciler sets a status condition and stops without requeueing.
+type terminalError struct {
+	message string
+}
+
+func (e *terminalError) Error() string {
+	return e.message
+}
+
+func (r *OGXServerReconciler) handleSentinelErrors(
+	ctx context.Context, instance *ogxiov1beta1.OGXServer, reconcileErr error,
+) (ctrl.Result, bool) {
+	logger := log.FromContext(ctx)
+
+	var requeueErr *requeueError
+	if errors.As(reconcileErr, &requeueErr) {
+		if statusUpdateErr := r.updateStatus(ctx, instance, nil); statusUpdateErr != nil {
+			logger.Error(statusUpdateErr, "failed to update status during adoption requeue")
+		}
+		return ctrl.Result{RequeueAfter: requeueErr.after}, true
+	}
+
+	var termErr *terminalError
+	if errors.As(reconcileErr, &termErr) {
+		if statusUpdateErr := r.updateStatus(ctx, instance, nil); statusUpdateErr != nil {
+			logger.Error(statusUpdateErr, "failed to update status for terminal error")
+		}
+		return ctrl.Result{}, true
+	}
+
+	return ctrl.Result{}, false
 }
 
 func (r *OGXServerReconciler) reconcileConfigMaps(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {

--- a/controllers/ogxserver_controller_test.go
+++ b/controllers/ogxserver_controller_test.go
@@ -478,10 +478,10 @@ func TestNetworkPolicyConfiguration(t *testing.T) {
 				if instance.Spec.Network == nil {
 					instance.Spec.Network = &ogxiov1beta1.NetworkSpec{}
 				}
-			instance.Spec.Network.Policy = &ogxiov1beta1.NetworkPolicySpec{
-				Enabled: boolPtr(false),
-			}
-			require.NoError(t, k8sClient.Update(t.Context(), instance))
+				instance.Spec.Network.Policy = &ogxiov1beta1.NetworkPolicySpec{
+					Enabled: boolPtr(false),
+				}
+				require.NoError(t, k8sClient.Update(t.Context(), instance))
 			},
 		},
 		{
@@ -508,11 +508,11 @@ func TestNetworkPolicyConfiguration(t *testing.T) {
 				if instance.Spec.Network == nil {
 					instance.Spec.Network = &ogxiov1beta1.NetworkSpec{}
 				}
-			instance.Spec.Network.Policy = &ogxiov1beta1.NetworkPolicySpec{
-				Enabled: boolPtr(false),
+				instance.Spec.Network.Policy = &ogxiov1beta1.NetworkPolicySpec{
+					Enabled: boolPtr(false),
+				}
 			}
-		}
-		require.NoError(t, k8sClient.Create(t.Context(), instance))
+			require.NoError(t, k8sClient.Create(t.Context(), instance))
 			t.Cleanup(func() { _ = k8sClient.Delete(t.Context(), instance) })
 
 			tt.setup(t, instance)

--- a/controllers/ogxserver_controller_test.go
+++ b/controllers/ogxserver_controller_test.go
@@ -149,6 +149,69 @@ func TestStorageConfiguration(t *testing.T) {
 	}
 }
 
+func TestDefaultPVCLifecycle(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	// --- arrange ---
+	namespace := createTestNamespace(t, "pvc-lifecycle")
+	pvcName := "pvc-test-pvc"
+	pvcKey := types.NamespacedName{Name: pvcName, Namespace: namespace.Name}
+	crKey := types.NamespacedName{Name: "pvc-test", Namespace: namespace.Name}
+
+	// --- act: create OGXServer with storage ---
+	instance := NewOGXServerBuilder().
+		WithName("pvc-test").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		Build()
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+
+	ReconcileOGXServer(t, instance)
+
+	// --- assert: PVC created without ownerRef, Deployment references it ---
+	pvc := AssertPVCExists(t, k8sClient, namespace.Name, pvcName)
+	require.Nil(t, metav1.GetControllerOf(pvc),
+		"Default PVC should not have a controller ownerRef")
+
+	deployment := &appsv1.Deployment{}
+	waitForResource(t, k8sClient, namespace.Name, "pvc-test", deployment)
+	AssertDeploymentUsesPVCStorage(t, deployment, pvcName)
+
+	// --- act: delete OGXServer ---
+	require.NoError(t, k8sClient.Delete(t.Context(), instance))
+	require.Eventually(t, func() bool {
+		return apierrors.IsNotFound(k8sClient.Get(t.Context(), crKey, &ogxiov1beta1.OGXServer{}))
+	}, testTimeout, testInterval, "OGXServer should be deleted")
+
+	// --- assert: PVC survives CR deletion ---
+	require.NoError(t, k8sClient.Get(t.Context(), pvcKey, pvc),
+		"PVC must survive OGXServer deletion")
+
+	// --- act: recreate OGXServer with same name ---
+	instance = NewOGXServerBuilder().
+		WithName("pvc-test").
+		WithNamespace(namespace.Name).
+		WithStorage(DefaultTestStorage()).
+		Build()
+	require.NoError(t, k8sClient.Create(t.Context(), instance))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(t.Context(), instance); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Cleanup: %v", err)
+		}
+	})
+
+	ReconcileOGXServer(t, instance)
+
+	// --- assert: PVC reused, Deployment references it ---
+	require.NoError(t, k8sClient.Get(t.Context(), pvcKey, pvc),
+		"PVC must still exist after recreate")
+	require.Nil(t, metav1.GetControllerOf(pvc),
+		"Reused PVC should still not have a controller ownerRef")
+
+	require.NoError(t, k8sClient.Get(t.Context(), crKey, deployment))
+	AssertDeploymentUsesPVCStorage(t, deployment, pvcName)
+}
+
 func TestConfigMapWatchingFunctionality(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 

--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -455,7 +455,7 @@ func configureTLSCABundle(ctx context.Context, r *OGXServerReconciler, instance 
 // configureUserConfig handles user configuration setup.
 func configureUserConfig(instance *ogxiov1beta1.OGXServer, podSpec *corev1.PodSpec) {
 	overrideConfig := instance.Spec.OverrideConfig
-	if overrideConfig == nil || overrideConfig.Name == "" {
+	if overrideConfig == nil || overrideConfig.Name == "" || overrideConfig.Key == "" {
 		return
 	}
 
@@ -465,6 +465,12 @@ func configureUserConfig(instance *ogxiov1beta1.OGXServer, podSpec *corev1.PodSp
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: overrideConfig.Name,
+				},
+				Items: []corev1.KeyToPath{
+					{
+						Key:  overrideConfig.Key,
+						Path: "config.yaml",
+					},
 				},
 			},
 		},

--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -379,7 +379,7 @@ func createCABundleVolume(managedConfigMapName string) corev1.Volume {
 }
 
 // configurePodStorage configures the pod storage and returns the complete pod spec.
-func configurePodStorage(ctx context.Context, r *OGXServerReconciler, instance *ogxiov1beta1.OGXServer, container corev1.Container) corev1.PodSpec {
+func configurePodStorage(ctx context.Context, r *OGXServerReconciler, instance *ogxiov1beta1.OGXServer, container corev1.Container, effectivePVCName string) corev1.PodSpec {
 	fsGroup := FSGroup
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{container},
@@ -389,7 +389,7 @@ func configurePodStorage(ctx context.Context, r *OGXServerReconciler, instance *
 	}
 
 	// Configure storage volumes
-	configureStorage(instance, &podSpec)
+	configureStorage(instance, &podSpec, effectivePVCName)
 
 	// Configure TLS CA bundle (with auto-detection support)
 	configureTLSCABundle(ctx, r, instance, &podSpec)
@@ -406,22 +406,21 @@ func configurePodStorage(ctx context.Context, r *OGXServerReconciler, instance *
 }
 
 // configureStorage handles storage volume configuration.
-func configureStorage(instance *ogxiov1beta1.OGXServer, podSpec *corev1.PodSpec) {
+func configureStorage(instance *ogxiov1beta1.OGXServer, podSpec *corev1.PodSpec, effectivePVCName string) {
 	if instance.Spec.Workload != nil && instance.Spec.Workload.Storage != nil {
-		configurePersistentStorage(instance, podSpec)
+		configurePersistentStorage(podSpec, effectivePVCName)
 	} else {
 		configureEmptyDirStorage(podSpec)
 	}
 }
 
 // configurePersistentStorage sets up PVC-based storage.
-func configurePersistentStorage(instance *ogxiov1beta1.OGXServer, podSpec *corev1.PodSpec) {
-	// Use PVC for persistent storage
+func configurePersistentStorage(podSpec *corev1.PodSpec, pvcName string) {
 	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 		Name: "ogx-storage",
 		VolumeSource: corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-				ClaimName: instance.GetEffectivePVCName(),
+				ClaimName: pvcName,
 			},
 		},
 	})

--- a/pkg/deploy/kustomizer.go
+++ b/pkg/deploy/kustomizer.go
@@ -127,6 +127,8 @@ func manageResource(
 }
 
 // createResource creates a new resource, setting an owner reference only if it's namespace-scoped.
+// PersistentVolumeClaims are intentionally excluded from ownerRef to prevent
+// data loss on CR deletion — PVCs must be cleaned up explicitly by users.
 func createResource(
 	ctx context.Context,
 	cli client.Client,
@@ -135,13 +137,12 @@ func createResource(
 	scheme *runtime.Scheme,
 	gvk schema.GroupVersionKind,
 ) error {
-	// Check if the resource is cluster-scoped (like a ClusterRole) to avoid
-	// incorrectly setting a namespace-bound owner reference on it.
 	isClusterScoped, err := isClusterScoped(cli.RESTMapper(), gvk)
 	if err != nil {
 		return fmt.Errorf("failed to determine resource scope: %w", err)
 	}
-	if !isClusterScoped {
+	skipOwnerRef := isClusterScoped || gvk.Kind == "PersistentVolumeClaim"
+	if !skipOwnerRef {
 		if err := ctrl.SetControllerReference(ownerInstance, obj, scheme); err != nil {
 			return fmt.Errorf("failed to set controller reference for %s: %w", gvk.Kind, err)
 		}

--- a/release/operator-openshift.yaml
+++ b/release/operator-openshift.yaml
@@ -10,7 +10,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: system/serving-cert
     controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     app.kubernetes.io/name: ogx-k8s-operator
@@ -6878,6 +6877,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ogx-k8s-operator-webhook-cert
   labels:
     app.kubernetes.io/name: ogx-k8s-operator
   name: ogx-k8s-operator-webhook-service
@@ -6994,33 +6995,11 @@ spec:
     matchLabels:
       app.kubernetes.io/name: ogx-k8s-operator
 ---
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: serving-cert
-  namespace: system
-spec:
-  dnsNames:
-  - ogx-k8s-operator-webhook-service.ogx-k8s-operator-system.svc
-  - ogx-k8s-operator-webhook-service.ogx-k8s-operator-system.svc.cluster.local
-  issuerRef:
-    kind: Issuer
-    name: selfsigned-issuer
-  secretName: ogx-k8s-operator-webhook-cert
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: selfsigned-issuer
-  namespace: system
-spec:
-  selfSigned: {}
----
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: system/serving-cert
+    service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app.kubernetes.io/name: ogx-k8s-operator
   name: ogx-k8s-operator-validating-webhook-configuration

--- a/release/operator-openshift.yaml
+++ b/release/operator-openshift.yaml
@@ -6542,22 +6542,9 @@ rules:
   - ""
   resources:
   - configmaps
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - persistentvolumeclaims
-  - serviceaccounts
-  - services
   verbs:
   - create
-  - delete
   - get
   - list
   - patch
@@ -6569,6 +6556,19 @@ rules:
   - pods
   verbs:
   - list
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/release/operator-openshift.yaml
+++ b/release/operator-openshift.yaml
@@ -6553,21 +6553,6 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-- apiGroups:
-  - ""
-  resources:
   - serviceaccounts
   - services
   verbs:
@@ -6578,6 +6563,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
 - apiGroups:
   - apps
   resources:

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -6554,21 +6554,6 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-- apiGroups:
-  - ""
-  resources:
   - serviceaccounts
   - services
   verbs:
@@ -6579,6 +6564,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
 - apiGroups:
   - apps
   resources:

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -10,7 +10,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: system/serving-cert
+    cert-manager.io/inject-ca-from: ogx-k8s-operator-system/ogx-k8s-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.17.2
   labels:
     app.kubernetes.io/name: ogx-k8s-operator
@@ -6988,22 +6988,22 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: serving-cert
-  namespace: system
+  name: ogx-k8s-operator-serving-cert
+  namespace: ogx-k8s-operator-system
 spec:
   dnsNames:
   - ogx-k8s-operator-webhook-service.ogx-k8s-operator-system.svc
   - ogx-k8s-operator-webhook-service.ogx-k8s-operator-system.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: selfsigned-issuer
+    name: ogx-k8s-operator-selfsigned-issuer
   secretName: ogx-k8s-operator-webhook-cert
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: selfsigned-issuer
-  namespace: system
+  name: ogx-k8s-operator-selfsigned-issuer
+  namespace: ogx-k8s-operator-system
 spec:
   selfSigned: {}
 ---
@@ -7011,7 +7011,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: system/serving-cert
+    cert-manager.io/inject-ca-from: ogx-k8s-operator-system/ogx-k8s-operator-serving-cert
   labels:
     app.kubernetes.io/name: ogx-k8s-operator
   name: ogx-k8s-operator-validating-webhook-configuration

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -6543,22 +6543,9 @@ rules:
   - ""
   resources:
   - configmaps
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - persistentvolumeclaims
-  - serviceaccounts
-  - services
   verbs:
   - create
-  - delete
   - get
   - list
   - patch
@@ -6570,6 +6557,19 @@ rules:
   - pods
   verbs:
   - list
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
**Pre-req:** Follow-up to #290 . That PR should be reviewed and merged first

This PR implements PR 2b of 003-ogx-rename: annotation-driven adoption of legacy LLSD resources into OGXServer, plus adoption-focused test coverage.

It adds controller logic to:

- adopt legacy storage (PVC) and networking (Service/Ingress) resources
- transfer ownership safely to the new OGXServer
- update adoption status conditions
- handle adoption-specific requeue flow
- clean up adopted networking when adoption annotations are removed
- Note invalid adoption annotations do not disrupt normal reconcile behavior.

