### PR TITLE
feat: Update E2E tests, controller tests, docs

### DIFF
--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -87,6 +87,13 @@ jobs:
           until docker exec kind-registry true 2>/dev/null; do sleep 1; done
           docker push kind-registry:5000/ogx-k8s-operator:latest
 
+      - name: Install cert-manager
+        run: |
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+          kubectl wait --for=condition=available --timeout=120s deployment/cert-manager -n cert-manager
+          kubectl wait --for=condition=available --timeout=120s deployment/cert-manager-webhook -n cert-manager
+          kubectl wait --for=condition=available --timeout=120s deployment/cert-manager-cainjector -n cert-manager
+
       - name: Deploy operator
         run: |
           # Deploy the operator

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Llama Stack K8s Operator
+# Contributing to OGX K8s Operator
 
-Thank you for your interest in contributing to the Llama Stack K8s Operator! This document provides guidelines and instructions for contributing to this project.
+Thank you for your interest in contributing to the OGX K8s Operator! This document provides guidelines and instructions for contributing to this project.
 
 ## Development Setup
 
@@ -131,9 +131,9 @@ make test TEST_PKGS=./pkg/deploy TEST_FLAGS="-v -run TestRenderManifest"
 // Good: Descriptive test names that explain behavior
 {
     name: "No storage configuration - should use emptyDir",
-    buildInstance: func(namespace string) *llamav1alpha1.LlamaStackDistribution {
-        return NewDistributionBuilder().
-            WithStorage(nil). // Clear intent: testing emptyDir behavior
+    buildInstance: func(namespace string) *ogxiov1beta1.OGXServer {
+        return NewServerBuilder().
+            WithStorage(nil).
             Build()
     },
 },

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# llama-stack-operator
-This repo hosts a kubernetes operator that is responsible for creating and managing [llama-stack](https://github.com/meta-llama/llama-stack) server.
+# ogx-k8s-operator
+This repo hosts a Kubernetes operator that creates and manages OGX (Open GenAI Stack) servers.
 
 
 ## Features
 
-- Automated deployment of Llama Stack servers
-- Support for multiple [distributions](https://github.com/meta-llama/llama-stack?tab=readme-ov-file#distributions) (includes Ollama, vLLM, and others)
+- Automated deployment of OGX servers
+- Support for multiple distributions (includes Ollama, vLLM, and others)
 - Customizable server configurations
 - Volume management for model storage
 - Kubernetes-native resource management
@@ -14,7 +14,7 @@ This repo hosts a kubernetes operator that is responsible for creating and manag
 
 - [Quick Start](#quick-start)
     - [Installation](#installation)
-    - [Deploying Llama Stack Server](#deploying-the-llama-stack-server)
+    - [Deploying the OGX Server](#deploying-the-ogx-server)
 - [Enabling Network Policies](#enabling-network-policies)
 - [Developer Guide](#developer-guide)
     - [Prerequisites](#prerequisites)
@@ -32,16 +32,16 @@ You can install the operator directly from a released version or the latest main
 To install the latest version from the main branch:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/llamastack/llama-stack-k8s-operator/main/release/operator.yaml
+kubectl apply -f https://raw.githubusercontent.com/ogx-ai/ogx-k8s-operator/main/release/operator.yaml
 ```
 
 To install a specific released version (e.g., v1.0.0), replace `main` with the desired tag:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/llamastack/llama-stack-k8s-operator/v1.0.0/release/operator.yaml
+kubectl apply -f https://raw.githubusercontent.com/ogx-ai/ogx-k8s-operator/v1.0.0/release/operator.yaml
 ```
 
-### Deploying the Llama Stack Server
+### Deploying the OGX Server
 
 1. Deploy the inference provider server (ollama, vllm)
 
@@ -71,111 +71,90 @@ Deploy vLLM with GPU support:
 ./hack/deploy-quickstart.sh --provider vllm --runtime-env "VLLM_TARGET_DEVICE=gpu,CUDA_VISIBLE_DEVICES=0"
 ```
 
-2. Create LlamaStackDistribution CR to get the server running. Example:
+2. Create an OGXServer CR to get the server running. Example:
 ```
-apiVersion: llamastack.io/v1alpha1
-kind: LlamaStackDistribution
+apiVersion: ogx.io/v1beta1
+kind: OGXServer
 metadata:
-  name: llamastackdistribution-sample
+  name: ogxserver-sample
 spec:
-  replicas: 1
-  server:
-    distribution:
-      name: starter
-    containerSpec:
+  distribution:
+    name: starter
+  workload:
+    replicas: 1
+    storage:
+      size: "20Gi"
+      mountPath: "/.ogx"
+    overrides:
       env:
       - name: OLLAMA_INFERENCE_MODEL
         value: "llama3.2:1b"
       - name: OLLAMA_URL
         value: "http://ollama-server-service.ollama-dist.svc.cluster.local:11434"
-    storage:
-      size: "20Gi"
-      mountPath: "/home/lls/.lls"
 ```
 3. Verify the server pod is running in the user defined namespace.
 
 ### Local Vector Storage (inline::milvus)
 
-To enable the `inline::milvus` local vector storage provider, set `ENABLE_INLINE_MILVUS` in `spec.server.containerSpec.env`. This is only supported in single-worker, single-replica deployments. Milvus-Lite uses SQLite internally and does not support concurrent access from multiple processes.
+To enable the `inline::milvus` local vector storage provider, set `ENABLE_INLINE_MILVUS` in `spec.workload.overrides.env`. This is only supported in single-worker, single-replica deployments. Milvus-Lite uses SQLite internally and does not support concurrent access from multiple processes.
 
 ### Using a ConfigMap for config.yaml configuration
 
-A ConfigMap can be used to store config.yaml configuration for each LlamaStackDistribution.
+A ConfigMap can be used to store config.yaml configuration for each OGXServer.
 Updates to the ConfigMap will restart the Pod to load the new data.
 
-Example to create a config.yaml ConfigMap, and a LlamaStackDistribution that references it:
+Example to create a config.yaml ConfigMap, and an OGXServer that references it:
 ```
 kubectl apply -f config/samples/example-with-configmap.yaml
 ```
 
 ## Enabling Network Policies
 
-The operator can create an ingress-only `NetworkPolicy` for each `LlamaStackDistribution`. By default, traffic is limited to:
-- All pods within the same namespace
-- The operator namespace (`llama-stack-k8s-operator-system`)
-
-### Enable the Feature Flag
-
-Network policies are disabled by default. Enable via ConfigMap:
-
-```bash
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: llama-stack-operator-config
-  namespace: llama-stack-k8s-operator-system
-data:
-  featureFlags: |
-    enableNetworkPolicy:
-      enabled: true
-EOF
-```
-
-### Configure Per-Instance Access
-
-Use `spec.network` to customize access controls:
+Network policies are enabled by default per-CR. Configure via `spec.network.policy`:
 
 ```yaml
-apiVersion: llamastack.io/v1alpha1
-kind: LlamaStackDistribution
+apiVersion: ogx.io/v1beta1
+kind: OGXServer
 metadata:
-  name: my-llsd
+  name: my-ogxs
 spec:
-  server:
-    distribution:
-      name: starter
+  distribution:
+    name: starter
   network:
-    exposeRoute: false          # Set true to create an Ingress for external access
-    allowedFrom:
-      namespaces:               # Explicit namespace names
-        - my-app-namespace
-        - monitoring
-      labels:                   # Namespaces matching these label keys
-        - team=frontend
+    externalAccess:
+      enabled: true
+      hostname: my-ogx.example.com
+    policy:
+      enabled: true
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: my-app-namespace
+          ports:
+            - protocol: TCP
+              port: 8321
 ```
 
 | Field | Description |
 |-------|-------------|
-| `network.exposeRoute` | When `true`, creates an Ingress for external access (default: `false`) |
-| `network.allowedFrom.namespaces` | List of namespace names allowed to access the service. Use `"*"` to allow all namespaces |
-| `network.allowedFrom.labels` | List of namespace label keys. Namespaces with these labels are allowed |
-
-Set `enabled: false` in the ConfigMap to disable; the operator will delete the managed policies.
+| `network.externalAccess.enabled` | When `true`, enables external access configuration for the server |
+| `network.externalAccess.hostname` | Hostname used for external access (for example, Ingress host) |
+| `network.policy.enabled` | When `true`, the operator creates a `NetworkPolicy` for the OGXServer workload |
+| `network.policy.ingress` | Ingress rules for the policy (for example, allowed sources and ports) |
 
 ## Image Mapping Overrides
 
-The operator supports ConfigMap-driven image updates for LLS Distribution images. This allows independent patching for security fixes or bug fixes without requiring a new operator version.
+The operator supports ConfigMap-driven image updates for OGX distribution images. This allows independent patching for security fixes or bug fixes without requiring a new operator version.
 
 ### Configuration
 
 Create or update the operator ConfigMap with an `image-overrides` key:
 
 ```yaml
-
-  image-overrides: |
-    starter-gpu: quay.io/custom/llama-stack:starter-gpu
-    starter: quay.io/custom/llama-stack:starter
+image-overrides: |
+  starter-gpu: quay.io/custom/ogx:starter-gpu
+  starter: quay.io/custom/ogx:starter
 ```
 
 ### Configuration Format
@@ -184,13 +163,13 @@ Use the distribution name directly as the key (e.g., `starter-gpu`, `starter`). 
 
 ### Example Usage
 
-To update the LLS Distribution image for all `starter` distributions:
+To update the OGX distribution image for all `starter` distributions:
 
 ```bash
-kubectl patch configmap llama-stack-operator-config -n llama-stack-k8s-operator-system --type merge -p '{"data":{"image-overrides":"starter: quay.io/opendatahub/llama-stack:latest"}}'
+kubectl patch configmap ogx-operator-config -n ogx-k8s-operator-system --type merge -p '{"data":{"image-overrides":"starter: quay.io/ogx-ai/ogx-server:latest"}}'
 ```
 
-This will cause all LlamaStackDistribution resources using the `starter` distribution to restart with the new image.
+This will cause all OGXServer resources using the `starter` distribution to restart with the new image.
 
 ## Developer Guide
 
@@ -216,10 +195,10 @@ This will cause all LlamaStackDistribution resources using the `starter` distrib
 - Custom operator image can be built using your local repository
 
   ```commandline
-  make image IMG=quay.io/<username>/llama-stack-k8s-operator:<custom-tag>
+  make image IMG=quay.io/<username>/ogx-k8s-operator:<custom-tag>
   ```
 
-  The default image used is `quay.io/llamastack/llama-stack-k8s-operator:latest` when not supply argument for `make image`
+  The default image used is `quay.io/ogx-ai/ogx-k8s-operator:latest` when not supply argument for `make image`
   To create a local file `local.mk` with env variables can overwrite the default values set in the `Makefile`.
 
 - Building multi-architecture images (ARM64, AMD64, etc.)
@@ -227,17 +206,17 @@ This will cause all LlamaStackDistribution resources using the `starter` distrib
   The operator supports building for multiple architectures including ARM64. To build and push multi-arch images:
 
   ```commandline
-  make image-buildx IMG=quay.io/<username>/llama-stack-k8s-operator:<custom-tag>
+  make image-buildx IMG=quay.io/<username>/ogx-k8s-operator:<custom-tag>
   ```
 
   By default, this builds for `linux/amd64,linux/arm64`. You can customize the platforms by setting the `PLATFORMS` variable:
 
   ```commandline
   # Build for specific platforms
-  make image-buildx IMG=quay.io/<username>/llama-stack-k8s-operator:<custom-tag> PLATFORMS=linux/amd64,linux/arm64
+  make image-buildx IMG=quay.io/<username>/ogx-k8s-operator:<custom-tag> PLATFORMS=linux/amd64,linux/arm64
 
   # Add more architectures (e.g., for future support)
-  make image-buildx IMG=quay.io/<username>/llama-stack-k8s-operator:<custom-tag> PLATFORMS=linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+  make image-buildx IMG=quay.io/<username>/ogx-k8s-operator:<custom-tag> PLATFORMS=linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
   ```
 
   **Note**:
@@ -260,11 +239,11 @@ This will cause all LlamaStackDistribution resources using the `starter` distrib
 
   ```commandline
   # Build and push a single-arch image (used by each matrix job on its native runner)
-  make image-build-push-single PLATFORM=linux/amd64 IMG=quay.io/<username>/llama-stack-k8s-operator:<tag>-amd64
+  make image-build-push-single PLATFORM=linux/amd64 IMG=quay.io/<username>/ogx-k8s-operator:<tag>-amd64
 
   # Create a multi-arch manifest from per-arch images (used by the final manifest job)
-  make image-create-manifest IMG=quay.io/<username>/llama-stack-k8s-operator:<tag> \
-    ARCH_IMGS="quay.io/<username>/llama-stack-k8s-operator:<tag>-amd64 quay.io/<username>/llama-stack-k8s-operator:<tag>-arm64"
+  make image-create-manifest IMG=quay.io/<username>/ogx-k8s-operator:<tag> \
+    ARCH_IMGS="quay.io/<username>/ogx-k8s-operator:<tag>-amd64 quay.io/<username>/ogx-k8s-operator:<tag>-arm64"
   ```
 
 - Building ARM64-only images
@@ -272,8 +251,8 @@ This will cause all LlamaStackDistribution resources using the `starter` distrib
   To build a single ARM64 image (useful for testing or ARM-native systems):
 
   ```commandline
-  make image-build-arm IMG=quay.io/<username>/llama-stack-k8s-operator:<custom-tag>
-  make image-push IMG=quay.io/<username>/llama-stack-k8s-operator:<custom-tag>
+  make image-build-arm IMG=quay.io/<username>/ogx-k8s-operator:<custom-tag>
+  make image-push IMG=quay.io/<username>/ogx-k8s-operator:<custom-tag>
   ```
 
   This works with both Docker and Podman.
@@ -287,18 +266,33 @@ This will cause all LlamaStackDistribution resources using the `starter` distrib
 
 ### Deployment
 
-**Deploying operator locally**
+**Deploying on vanilla Kubernetes (cert-manager)**
 
 - Deploy the created image in your cluster using following command:
 
   ```commandline
-  make deploy IMG=quay.io/<username>/llama-stack-k8s-operator:<custom-tag>
+  make deploy IMG=quay.io/<username>/ogx-k8s-operator:<custom-tag>
   ```
 
 - To remove resources created during installation use:
 
   ```commandline
   make undeploy
+  ```
+
+**Deploying on OpenShift**
+
+OpenShift clusters use the built-in service-serving-cert-signer for webhook TLS
+(no cert-manager required):
+
+  ```commandline
+  make deploy-openshift IMG=quay.io/<username>/ogx-k8s-operator:<custom-tag>
+  ```
+
+- To remove resources:
+
+  ```commandline
+  make undeploy-openshift
   ```
 
 ## Running E2E Tests

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Network policies are enabled by default per-CR. Configure via `spec.network.poli
 apiVersion: ogx.io/v1beta1
 kind: OGXServer
 metadata:
-  name: my-ogxs
+  name: my-ogxserver
 spec:
   distribution:
     name: starter

--- a/api/v1beta1/ogxserver_types.go
+++ b/api/v1beta1/ogxserver_types.go
@@ -578,7 +578,6 @@ type OGXServerStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=ogxs
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 // +kubebuilder:printcolumn:name="Distribution",type="string",JSONPath=".status.resolvedDistribution.image",priority=1

--- a/config/crd/bases/ogx.io_ogxservers.yaml
+++ b/config/crd/bases/ogx.io_ogxservers.yaml
@@ -11,8 +11,6 @@ spec:
     kind: OGXServer
     listKind: OGXServerList
     plural: ogxservers
-    shortNames:
-    - ogxs
     singular: ogxserver
   scope: Namespaced
   versions:

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -19,5 +19,5 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
-- ogxs_viewer_role.yaml
-- ogxs_editor_role.yaml
+- ogxserver_viewer_role.yaml
+- ogxserver_editor_role.yaml

--- a/config/rbac/ogxserver_editor_role.yaml
+++ b/config/rbac/ogxserver_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ogxs-editor-role
+  name: ogxserver-editor-role
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/config/rbac/ogxserver_viewer_role.yaml
+++ b/config/rbac/ogxserver_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ogxs-viewer-role
+  name: ogxserver-viewer-role
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:

--- a/config/samples/example-with-ca-bundle.yaml
+++ b/config/samples/example-with-ca-bundle.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: llama-stack-config
+  name: ogx-server-config
   labels:
     ogx.io/watch: "true"
 data:
   config.yaml: |
-    # Llama Stack Configuration
+    # OGX Server Configuration
     version: '2'
     image_name: starter
     apis:
@@ -55,7 +55,7 @@ spec:
   distribution:
     name: starter
   overrideConfig:
-    name: llama-stack-config
+    name: ogx-server-config
     key: config.yaml
   tls:
     trust:

--- a/config/samples/example-with-ca-bundle.yaml
+++ b/config/samples/example-with-ca-bundle.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: llama-stack-config
+  labels:
+    ogx.io/watch: "true"
 data:
   config.yaml: |
     # Llama Stack Configuration
@@ -53,14 +55,13 @@ spec:
   distribution:
     name: starter
   overrideConfig:
-    configMapName: llama-stack-config
-  caBundle:
-    configMapName: custom-ca-bundle
-    # configMapNamespace: ""  # Optional - defaults to the same namespace as the CR
-    # configMapKeys not specified - defaults to ["ca-bundle.crt"]
-    # configMapKeys: # Specify multiple keys to concatenate into a single CA bundle
-    #   - ca-bundle1.crt
-    #   - ca-bundle2.crt
+    name: llama-stack-config
+    key: config.yaml
+  tls:
+    trust:
+      caCertificates:
+        - name: custom-ca-bundle
+          key: ca-bundle.crt
   network:
     port: 8321
   workload:

--- a/config/samples/example-with-configmap.yaml
+++ b/config/samples/example-with-configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: llama-stack-config
+  labels:
+    ogx.io/watch: "true"
 data:
   config.yaml: |
     # Llama Stack Configuration
@@ -53,7 +55,8 @@ spec:
   distribution:
     name: starter
   overrideConfig:
-    configMapName: llama-stack-config
+    name: llama-stack-config
+    key: config.yaml
   network:
     port: 8321
   workload:

--- a/config/samples/example-with-configmap.yaml
+++ b/config/samples/example-with-configmap.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: llama-stack-config
+  name: ogx-server-config
   labels:
     ogx.io/watch: "true"
 data:
   config.yaml: |
-    # Llama Stack Configuration
+    # OGX Server Configuration
     version: '2'
     image_name: starter
     apis:
@@ -55,7 +55,7 @@ spec:
   distribution:
     name: starter
   overrideConfig:
-    name: llama-stack-config
+    name: ogx-server-config
     key: config.yaml
   network:
     port: 8321

--- a/controllers/ogxserver_controller_test.go
+++ b/controllers/ogxserver_controller_test.go
@@ -798,7 +798,7 @@ func TestParseImageMappingOverrides_SingleOverride(t *testing.T) {
 
 	// Test data with single override
 	configMapData := map[string]string{
-		"image-overrides": "starter: quay.io/custom/llama-stack:starter",
+		"image-overrides": "starter: quay.io/custom/ogx-server:starter",
 	}
 
 	// Call the function
@@ -806,7 +806,7 @@ func TestParseImageMappingOverrides_SingleOverride(t *testing.T) {
 
 	// Assertions
 	require.Len(t, result, 1, "Should have exactly one override")
-	require.Equal(t, "quay.io/custom/llama-stack:starter", result["starter"], "Override should match expected value")
+	require.Equal(t, "quay.io/custom/ogx-server:starter", result["starter"], "Override should match expected value")
 }
 
 func TestParseImageMappingOverrides_InvalidYAML(t *testing.T) {
@@ -866,7 +866,7 @@ func TestNewOGXServerReconciler_WithImageOverrides(t *testing.T) {
 			Namespace: operatorNamespace.Name,
 		},
 		Data: map[string]string{
-			"image-overrides": "starter: quay.io/custom/llama-stack:starter",
+			"image-overrides": "starter: quay.io/custom/ogx-server:starter",
 		},
 	}
 	require.NoError(t, k8sClient.Create(t.Context(), configMap))
@@ -890,7 +890,7 @@ func TestNewOGXServerReconciler_WithImageOverrides(t *testing.T) {
 	require.NoError(t, err, "Should create reconciler successfully")
 	require.NotNil(t, reconciler, "Reconciler should not be nil")
 	require.Len(t, reconciler.ImageMappingOverrides, 1, "Should have one image override")
-	require.Equal(t, "quay.io/custom/llama-stack:starter",
+	require.Equal(t, "quay.io/custom/ogx-server:starter",
 		reconciler.ImageMappingOverrides["starter"], "Override should match expected value")
 }
 
@@ -959,7 +959,7 @@ func TestConfigMapUpdateTriggersReconciliation(t *testing.T) {
 	if configMap.Data == nil {
 		configMap.Data = make(map[string]string)
 	}
-	configMap.Data["image-overrides"] = "starter: quay.io/custom/llama-stack:starter"
+	configMap.Data["image-overrides"] = "starter: quay.io/custom/ogx-server:starter"
 	require.NoError(t, k8sClient.Update(t.Context(), configMap))
 
 	// Reconcile with the same reconciler instance. refreshOperatorConfig (called
@@ -974,7 +974,7 @@ func TestConfigMapUpdateTriggersReconciliation(t *testing.T) {
 	waitForResourceWithKeyAndCondition(
 		t, k8sClient, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace},
 		deployment, func() bool {
-			return deployment.Spec.Template.Spec.Containers[0].Image == "quay.io/custom/llama-stack:starter"
+			return deployment.Spec.Template.Spec.Containers[0].Image == "quay.io/custom/ogx-server:starter"
 		}, "Deployment should be updated with new image")
 }
 

--- a/docs/additional/ca-bundle-configuration.md
+++ b/docs/additional/ca-bundle-configuration.md
@@ -1,19 +1,21 @@
-# CA Bundle Configuration for LlamaStackDistribution
+# CA Bundle Configuration for OGXServer
 
-This document explains how to configure custom CA bundles for LlamaStackDistribution to enable secure communication with external LLM providers using self-signed certificates.
+This document explains how to configure custom CA bundles for OGXServer to enable secure communication with external LLM providers using self-signed certificates.
 
 ## Overview
 
 The CA bundle configuration allows you to:
 - Use self-signed certificates for external LLM API connections
 - Trust custom Certificate Authorities (CAs) for secure communication
-- Mount CA certificates from ConfigMaps into the LlamaStack server pods
+- Mount CA certificates from ConfigMaps into the OGX server pods
+
+Source ConfigMaps must live in the **same namespace** as the OGXServer and must include the label **`ogx.io/watch: "true"`** so the operator can watch them for changes.
 
 ## How It Works
 
 When you configure a CA bundle:
 
-1. **ConfigMap Storage**: CA certificates are stored in a Kubernetes ConfigMap (source ConfigMap)
+1. **ConfigMap Storage**: CA certificates are stored in a Kubernetes ConfigMap (source ConfigMap) in the same namespace as the OGXServer, with `ogx.io/watch: "true"` on the ConfigMap metadata
 2. **Controller Processing**: The operator controller reads and validates certificates from the source ConfigMap(s)
 3. **Concatenation**: Valid certificates are concatenated into a single PEM file using Go's `encoding/pem` package
 4. **Managed ConfigMap**: The operator creates a managed ConfigMap named `{instance-name}-ca-bundle` containing the concatenated bundle
@@ -26,7 +28,7 @@ When you configure a CA bundle:
 The operator processes CA bundle certificates in the controller before deployment:
 
 **Processing Steps:**
-1. The controller reads CA certificate data from the source ConfigMap(s) specified in `tlsConfig.caBundle`
+1. The controller reads CA certificate data from the source ConfigMap(s) specified in `spec.tls.trust.caCertificates`
 2. Each certificate is validated using Go's `encoding/pem` package to ensure proper PEM format
 3. Valid `CERTIFICATE` blocks are extracted and concatenated into a single PEM file
 4. The concatenated bundle is stored in a managed ConfigMap named `{instance-name}-ca-bundle` with key `ca-bundle.crt`
@@ -46,46 +48,46 @@ The operator processes CA bundle certificates in the controller before deploymen
 ### Basic CA Bundle Configuration
 
 ```yaml
-apiVersion: llamastack.io/v1alpha1
-kind: LlamaStackDistribution
+apiVersion: ogx.io/v1beta1
+kind: OGXServer
 metadata:
-  name: my-llama-stack
+  name: my-ogx-server
 spec:
-  server:
-    distribution:
-      name: hf-serverless
-    tlsConfig:
-      caBundle:
-        configMapName: my-ca-bundle
-        # configMapNamespace: default  # Optional - defaults to CR namespace
-        # configMapKey: ca-bundle.crt           # Optional - defaults to "ca-bundle.crt"
+  distribution:
+    name: hf-serverless
+  tls:
+    trust:
+      caCertificates:
+        - name: my-ca-bundle
+          key: ca-bundle.crt
 ```
 
-### Multiple CA Bundle Keys Configuration (RHOAI Pattern)
+### Multiple CA Sources (RHOAI Pattern)
 
 ```yaml
-apiVersion: llamastack.io/v1alpha1
-kind: LlamaStackDistribution
+apiVersion: ogx.io/v1beta1
+kind: OGXServer
 metadata:
-  name: my-llama-stack
+  name: my-ogx-server
 spec:
-  server:
-    distribution:
-      name: hf-serverless
-    tlsConfig:
-      caBundle:
-        configMapName: odh-trusted-ca-bundle
-        # configMapNamespace: default  # Optional - defaults to CR namespace
-        configMapKeys:                   # Multiple keys from same ConfigMap
-          - ca-bundle.crt                # CNO-injected cluster CAs
-          - odh-ca-bundle.crt           # User-specified custom CAs
+  distribution:
+    name: hf-serverless
+  tls:
+    trust:
+      caCertificates:
+        - name: odh-trusted-ca-bundle
+          key: ca-bundle.crt        # CNO-injected cluster CAs
+        - name: odh-trusted-ca-bundle
+          key: odh-ca-bundle.crt    # User-specified custom CAs
 ```
 
 ### Configuration Fields
 
-- `configMapName` (required): Name of the ConfigMap containing CA certificates
-- `configMapNamespace` (optional): Namespace of the ConfigMap. Defaults to the same namespace as the LlamaStackDistribution
-- `configMapKeys` (optional): Array of keys within the ConfigMap containing CA bundle data. All certificates from these keys will be concatenated into a single CA bundle file. If not specified, defaults to `["ca-bundle.crt"]`
+- `spec.tls.trust.caCertificates` (array of ConfigMapKeyRef): Each entry references a specific key in a ConfigMap containing PEM-encoded CA certificates. All certificates from all entries are concatenated into a single CA bundle file.
+  - `name` (required): Name of the ConfigMap containing the CA certificate.
+  - `key` (required): Key within the ConfigMap containing the PEM-encoded certificate data.
+
+**ConfigMap requirements:** The referenced ConfigMap must include `metadata.labels["ogx.io/watch"]` set to `"true"`.
 
 ## Examples
 
@@ -96,69 +98,62 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: my-ca-bundle
+  labels:
+    ogx.io/watch: "true"
 data:
   ca-bundle.crt: |
     -----BEGIN CERTIFICATE-----
     # ... your CA certificate data here ...
     -----END CERTIFICATE-----
 ---
-apiVersion: llamastack.io/v1alpha1
-kind: LlamaStackDistribution
+apiVersion: ogx.io/v1beta1
+kind: OGXServer
 metadata:
-  name: secure-llama-stack
+  name: secure-ogx-server
 spec:
-  server:
-    distribution:
-      name: hf-serverless
-    tlsConfig:
-      caBundle:
-        configMapName: my-ca-bundle
+  distribution:
+    name: hf-serverless
+  tls:
+    trust:
+      caCertificates:
+        - name: my-ca-bundle
+          key: ca-bundle.crt
 ```
 
 ### Example 2: Custom Key Name
+
+Reference a non-default key name from the ConfigMap:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: my-ca-bundle
+  labels:
+    ogx.io/watch: "true"
 data:
   custom-ca.pem: |
     -----BEGIN CERTIFICATE-----
     # ... your CA certificate data here ...
     -----END CERTIFICATE-----
 ---
-apiVersion: llamastack.io/v1alpha1
-kind: LlamaStackDistribution
+apiVersion: ogx.io/v1beta1
+kind: OGXServer
 metadata:
-  name: secure-llama-stack
+  name: secure-ogx-server
 spec:
-  server:
-    distribution:
-      name: hf-serverless
-    tlsConfig:
-      caBundle:
-        configMapName: my-ca-bundle
-        configMapKey: custom-ca.pem
+  distribution:
+    name: hf-serverless
+  tls:
+    trust:
+      caCertificates:
+        - name: my-ca-bundle
+          key: custom-ca.pem
 ```
 
-### Example 3: Cross-Namespace CA Bundle
+### Example 3: Same Namespace Only
 
-```yaml
-apiVersion: llamastack.io/v1alpha1
-kind: LlamaStackDistribution
-metadata:
-  name: secure-llama-stack
-  namespace: my-namespace
-spec:
-  server:
-    distribution:
-      name: hf-serverless
-    tlsConfig:
-      caBundle:
-        configMapName: global-ca-bundle
-        configMapNamespace: kube-system
-```
+CA bundle ConfigMaps must be in the **same namespace** as the OGXServer. There is no cross-namespace reference support; create or copy the bundle ConfigMap into the OGXServer namespace before referencing it.
 
 ### Example 4: RHOAI Pattern with Multiple CA Sources
 
@@ -168,6 +163,7 @@ kind: ConfigMap
 metadata:
   name: odh-trusted-ca-bundle
   labels:
+    ogx.io/watch: "true"
     config.openshift.io/inject-trusted-cabundle: "true"
 data:
   ca-bundle.crt: |
@@ -184,23 +180,31 @@ data:
     # ... custom CA certificate 2 ...
     -----END CERTIFICATE-----
 ---
-apiVersion: llamastack.io/v1alpha1
-kind: LlamaStackDistribution
+apiVersion: ogx.io/v1beta1
+kind: OGXServer
 metadata:
-  name: rhoai-llama-stack
+  name: rhoai-ogx-server
 spec:
-  server:
-    distribution:
-      name: hf-serverless
-    tlsConfig:
-      caBundle:
-        configMapName: odh-trusted-ca-bundle
-        configMapKeys:
-          - ca-bundle.crt      # Cluster CAs
-          - odh-ca-bundle.crt  # Custom CAs
+  distribution:
+    name: hf-serverless
+  tls:
+    trust:
+      caCertificates:
+        - name: odh-trusted-ca-bundle
+          key: ca-bundle.crt
+        - name: odh-trusted-ca-bundle
+          key: odh-ca-bundle.crt
 ```
 
 ## Creating CA Bundle ConfigMaps
+
+Every CA bundle ConfigMap must be labeled so the operator watches it:
+
+```yaml
+metadata:
+  labels:
+    ogx.io/watch: "true"
+```
 
 ### From Certificate Files
 
@@ -212,6 +216,9 @@ kubectl create configmap my-ca-bundle --from-file=ca-bundle.crt=/path/to/your/ca
 kubectl create configmap my-ca-bundle \
   --from-file=ca-bundle.crt=/path/to/your/ca1.crt \
   --from-file=additional-ca.crt=/path/to/your/ca2.crt
+
+# Label for OGX (required before the operator will track updates)
+kubectl label configmap my-ca-bundle ogx.io/watch=true
 ```
 
 ### From Certificate Content
@@ -219,6 +226,7 @@ kubectl create configmap my-ca-bundle \
 ```bash
 # Create a ConfigMap with certificate content
 kubectl create configmap my-ca-bundle --from-literal=ca-bundle.crt="$(cat /path/to/your/ca.crt)"
+kubectl label configmap my-ca-bundle ogx.io/watch=true
 ```
 
 ## Use Cases
@@ -229,36 +237,39 @@ When using private cloud LLM providers with self-signed certificates:
 
 ```yaml
 spec:
-  server:
-    distribution:
-      name: hf-serverless
-    containerSpec:
+  distribution:
+    name: hf-serverless
+  workload:
+    overrides:
       env:
-      - name: HF_API_KEY
-        valueFrom:
-          secretKeyRef:
-            name: hf-api-key
-            key: token
-    userConfig:
-      configMapName: llama-stack-config
-    tlsConfig:
-      caBundle:
-        configMapName: private-cloud-ca-bundle
+        - name: HF_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: hf-api-key
+              key: token
+  overrideConfig:
+    name: ogx-config
+    key: config.yaml
+  tls:
+    trust:
+      caCertificates:
+        - name: private-cloud-ca-bundle
+          key: ca-bundle.crt
 ```
 
 ### 2. Internal Enterprise APIs
 
-For enterprise environments with internal CAs:
+For enterprise environments with internal CAs, place the CA bundle ConfigMap in the same namespace as the OGXServer and reference it by name:
 
 ```yaml
 spec:
-  server:
-    distribution:
-      name: hf-endpoint
-    tlsConfig:
-      caBundle:
-        configMapName: enterprise-ca-bundle
-        configMapNamespace: security-system
+  distribution:
+    name: hf-endpoint
+  tls:
+    trust:
+      caCertificates:
+        - name: enterprise-ca-bundle
+          key: ca-bundle.crt
 ```
 
 ### 3. Development/Testing
@@ -267,13 +278,13 @@ For development environments with self-signed certificates:
 
 ```yaml
 spec:
-  server:
-    distribution:
-      name: ollama
-    tlsConfig:
-      caBundle:
-        configMapName: dev-ca-bundle
-        configMapKey: development-ca.pem
+  distribution:
+    name: ollama
+  tls:
+    trust:
+      caCertificates:
+        - name: dev-ca-bundle
+          key: development-ca.pem
 ```
 
 ## Troubleshooting
@@ -284,12 +295,13 @@ spec:
 2. **Permission Denied**: Check that the operator has permissions to read the ConfigMap
 3. **Invalid Certificate**: Verify the certificate format is correct (PEM format)
 4. **Pod Not Restarting**: ConfigMap changes trigger automatic pod restarts via annotations
+5. **ConfigMap Not Watched**: Ensure the source ConfigMap has label `ogx.io/watch: "true"`
 
 ### Common Error Messages and Solutions
 
 #### "CA bundle key not found in ConfigMap"
 - **Cause**: The specified key doesn't exist in the ConfigMap data
-- **Solution**: Check the key name in your LlamaStackDistribution spec, default is "ca-bundle.crt"
+- **Solution**: Check the `key` field in your `spec.tls.trust.caCertificates` entry matches an existing key in the ConfigMap
 - **Example**: Verify `kubectl get configmap my-ca-bundle -o yaml` shows your expected key
 
 #### "Invalid CA bundle format"
@@ -298,9 +310,9 @@ spec:
 - **Example**: Valid format starts with `-----BEGIN CERTIFICATE-----`
 
 #### "Referenced CA bundle ConfigMap not found"
-- **Cause**: The ConfigMap specified in tlsConfig.caBundle.configMapName doesn't exist
-- **Solution**: Create the ConfigMap first, then apply the LlamaStackDistribution
-- **Example**: `kubectl create configmap my-ca-bundle --from-file=ca-bundle.crt=my-ca.crt`
+- **Cause**: The ConfigMap specified in `spec.tls.trust.caCertificates[].name` doesn't exist or is not in the same namespace as the OGXServer
+- **Solution**: Create the ConfigMap in the OGX namespace first, label it with `ogx.io/watch=true`, then apply the OGXServer
+- **Example**: `kubectl create configmap my-ca-bundle --from-file=ca-bundle.crt=my-ca.crt && kubectl label configmap my-ca-bundle ogx.io/watch=true`
 
 #### "No valid certificates found in CA bundle"
 - **Cause**: The ConfigMap contains data but no parseable certificates
@@ -319,13 +331,13 @@ spec:
 kubectl get configmap my-ca-bundle -o yaml
 
 # Check pod environment variables
-kubectl describe pod <llama-stack-pod-name>
+kubectl describe pod <ogx-pod-name>
 
 # Check mounted certificates
-kubectl exec <llama-stack-pod-name> -- ls -la /etc/ssl/certs/ca-bundle/
+kubectl exec <ogx-pod-name> -- ls -la /etc/ssl/certs/ca-bundle/
 
 # Check SSL_CERT_FILE environment variable
-kubectl exec <llama-stack-pod-name> -- env | grep SSL_CERT_FILE
+kubectl exec <ogx-pod-name> -- env | grep SSL_CERT_FILE
 
 # Validate certificate format locally
 openssl x509 -text -noout -in ca-bundle.crt
@@ -339,10 +351,11 @@ openssl verify -CAfile ca-bundle.crt server.crt
 
 ### Validation Checklist
 
-Before deploying a LlamaStackDistribution with CA bundle:
+Before deploying an OGXServer with CA bundle:
 
-- [ ] ConfigMap exists in the correct namespace
-- [ ] ConfigMap contains the specified key (default: "ca-bundle.crt")
+- [ ] ConfigMap exists in the **same namespace** as the OGXServer
+- [ ] ConfigMap has label `ogx.io/watch: "true"`
+- [ ] ConfigMap contains the key referenced in `spec.tls.trust.caCertificates[].key`
 - [ ] Certificate data is in PEM format
 - [ ] Certificate data contains valid X.509 certificates
 - [ ] Operator has read permissions on the ConfigMap
@@ -353,7 +366,7 @@ Before deploying a LlamaStackDistribution with CA bundle:
 
 1. **ConfigMap Security**: ConfigMaps are stored in plain text in etcd. Consider using appropriate RBAC policies
 2. **Certificate Rotation**: Update ConfigMaps when certificates expire or are rotated
-3. **Namespace Isolation**: Use appropriate namespaces to isolate CA bundles
+3. **Namespace Isolation**: CA bundle ConfigMaps must reside in the same namespace as the OGXServer; use namespaces to isolate workloads and secrets
 4. **Audit Trail**: Monitor ConfigMap changes in production environments
 5. **Principle of Least Privilege**: Only grant necessary permissions to access CA bundle ConfigMaps
 6. **Resource Limits**: The operator enforces limits during certificate concatenation (10MB max bundle size, 1000 max certificates) to prevent resource exhaustion
@@ -365,4 +378,4 @@ Before deploying a LlamaStackDistribution with CA bundle:
 - ConfigMap size limits apply (1MB by default for source ConfigMaps)
 - Maximum bundle size is 10MB and maximum 1000 certificates (enforced by controller)
 - Certificate validation is handled by Go's `encoding/pem` and `crypto/x509` packages in the controller
-- Cross-namespace ConfigMap access requires appropriate RBAC permissions
+- The CA bundle ConfigMap must be in the same namespace as the OGXServer (cross-namespace references are not supported)

--- a/docs/create-operator.md
+++ b/docs/create-operator.md
@@ -116,7 +116,7 @@ metadata:
 spec:
   sourceType: grpc
   image: $REGISTRY/$REGISTRY_NAMESPACE/ogx-catalog:$TAG # Your catalog image from Step 3.5
-  displayName: "Llama Stack Operator Catalog (dev)"
+  displayName: "OGX Operator Catalog (dev)"
   publisher: "Red Hat Community"
   updateStrategy:
     registryPoll:
@@ -135,5 +135,5 @@ After applying the `CatalogSource`, allow a few moments for OpenShift to process
 
 1.  Log in to the OpenShift Web Console.
 2.  Navigate to **Operators \> OperatorHub**.
-3.  In the "Catalog Sources" filter, you should see "Llama Stack Operator Catalog" listed.
+3.  In the "Catalog Sources" filter, you should see "OGX Operator Catalog" listed.
 4.  Filter by this catalog, and your OGX K8s operator should appear, ready for installation.

--- a/docs/create-operator.md
+++ b/docs/create-operator.md
@@ -1,10 +1,10 @@
-# Deploying the `llama-stack-k8s-operator` as an OpenShift Catalog Item
+# Deploying the `ogx-k8s-operator` as an OpenShift Catalog Item
 
-This document outlines the steps required to package the `llama-stack-k8s-operator` into an Operator Bundle and make it available as a catalog item in OpenShift's OperatorHub.
+This document outlines the steps required to package the `ogx-k8s-operator` into an Operator Bundle and make it available as a catalog item in OpenShift's OperatorHub.
 
 ## Overview
 
-To expose the `llama-stack-k8s-operator` through the OpenShift OperatorHub, we need to package it according to the Operator Lifecycle Manager (OLM) specifications. This involves creating an Operator Bundle, building a bundle image, compiling a custom catalog image, and finally, registering this catalog with OpenShift using a `CatalogSource`.
+To expose the `ogx-k8s-operator` through the OpenShift OperatorHub, we need to package it according to the Operator Lifecycle Manager (OLM) specifications. This involves creating an Operator Bundle, building a bundle image, compiling a custom catalog image, and finally, registering this catalog with OpenShift using a `CatalogSource`.
 
 ## 2 Prerequisites
 
@@ -22,11 +22,11 @@ Follow these steps to prepare and deploy your operator.
 
 ### Clone the Operator Repository
 
-Start by cloning the `llama-stack-k8s-operator` repository to your local machine:
+Start by cloning the `ogx-k8s-operator` repository to your local machine:
 
 ```bash
-git clone https://github.com/llamastack/llama-stack-k8s-operator.git
-cd llama-stack-k8s-operator
+git clone https://github.com/ogx-ai/ogx-k8s-operator.git
+cd ogx-k8s-operator
 ```
 
 ### Set Env Variables
@@ -44,8 +44,8 @@ The operator's container image needs to be built and pushed to a container regis
 **Note:** Replace `<your-namespace>` with your actual registry and namespace.
 
 ```bash
-make image-build IMG=$REGISTRY/$REGISTRY_NAMESPACE/llama-stack-operator:$TAG
-podman push $REGISTRY/$REGISTRY_NAMESPACE/llama-stack-operator:$TAG
+make image-build IMG=$REGISTRY/$REGISTRY_NAMESPACE/ogx-k8s-operator:$TAG
+podman push $REGISTRY/$REGISTRY_NAMESPACE/ogx-k8s-operator:$TAG
 ```
 
 ### 3.3. Generate the Operator Bundle
@@ -58,7 +58,7 @@ An Operator Bundle is a directory containing the necessary manifests that descri
 make bundle
 ```
 
-After running `make bundle`, inspect the contents of the newly created `bundle/manifests/bases` directory. Pay close attention to the `llama-stack-k8s-operator.clusterserviceversion.yaml` file. You may need to edit this file to:
+After running `make bundle`, inspect the contents of the newly created `bundle/manifests/bases` directory. Pay close attention to the `ogx-k8s-operator.clusterserviceversion.yaml` file. You may need to edit this file to:
 
   * **`spec.installModes`**: Should be se to `AllNamespaces`
   * **`spec.replaces`**: If you have previous versions of the operator, this field is crucial for OLM to manage upgrades.
@@ -71,8 +71,8 @@ After running `make bundle`, inspect the contents of the newly created `bundle/m
 The generated bundle needs to be packaged into its own container image.
 
 ```bash
-make bundle-build BUNDLE_IMG=$REGISTRY/$REGISTRY_NAMESPACE/llama-stack-operator-bundle:$TAG
-podman push $REGISTRY/$REGISTRY_NAMESPACE/llama-stack-operator-bundle:$TAG
+make bundle-build BUNDLE_IMG=$REGISTRY/$REGISTRY_NAMESPACE/ogx-k8s-operator-bundle:$TAG
+podman push $REGISTRY/$REGISTRY_NAMESPACE/ogx-k8s-operator-bundle:$TAG
 ```
 
 ### 3.5. Create a Custom Catalog (Index) Image
@@ -86,17 +86,17 @@ We'll use the `opm` (Operator Package Manager) CLI tool, which is part of the Op
 #    This creates a Dockerfile for the catalog and an empty index.yaml.
 #    You can create a new directory for your catalog, e.g., 'catalog_dir'.
 mkdir -p catalog_dir
-opm init llama-stack-catalog --output yaml > catalog_dir/index.yaml
+opm init ogx-catalog --output yaml > catalog_dir/index.yaml
 
 # 2. Add your operator bundle to the catalog.
 #    Replace with your actual bundle image.
 opm index add \
-  --bundles $REGISTRY/$REGISTRY_NAMESPACE/llama-stack-operator-bundle:$TAG \
-  --tag $REGISTRY/$REGISTRY_NAMESPACE/llama-stack-catalog:$TAG \
+  --bundles $REGISTRY/$REGISTRY_NAMESPACE/ogx-k8s-operator-bundle:$TAG \
+  --tag $REGISTRY/$REGISTRY_NAMESPACE/ogx-catalog:$TAG \
   --build-tool podman
 
 # 3. Push the catalog image to your registry.
-podman push $REGISTRY/$REGISTRY_NAMESPACE/llama-stack-catalog:$TAG
+podman push $REGISTRY/$REGISTRY_NAMESPACE/ogx-catalog:$TAG
 ```
 
 ### 3.6. Create a `CatalogSource` in OpenShift
@@ -109,13 +109,13 @@ Create a YAML file (e.g., `.openshift/catalog-item.yaml`):
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: llama-stack-catalog
+  name: ogx-catalog
   namespace: openshift-marketplace # Standard namespace for CatalogSources
   labels:
     environment: dev
 spec:
   sourceType: grpc
-  image: $REGISTRY/$REGISTRY_NAMESPACE/llama-stack-catalog:$TAG # Your catalog image from Step 3.5
+  image: $REGISTRY/$REGISTRY_NAMESPACE/ogx-catalog:$TAG # Your catalog image from Step 3.5
   displayName: "Llama Stack Operator Catalog (dev)"
   publisher: "Red Hat Community"
   updateStrategy:
@@ -136,4 +136,4 @@ After applying the `CatalogSource`, allow a few moments for OpenShift to process
 1.  Log in to the OpenShift Web Console.
 2.  Navigate to **Operators \> OperatorHub**.
 3.  In the "Catalog Sources" filter, you should see "Llama Stack Operator Catalog" listed.
-4.  Filter by this catalog, and your `LlamaStack` operator should appear, ready for installation.
+4.  Filter by this catalog, and your OGX K8s operator should appear, ready for installation.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,0 +1,342 @@
+# Migration Guide: LlamaStackDistribution to OGXServer
+
+This guide covers migrating from the `LlamaStackDistribution` operator (`llamastack.io/v1alpha1`) to the `OGXServer` operator (`ogx.io/v1beta1`).
+
+## Breaking Change
+
+This is a **breaking change**. There is no coexistence period and no conversion webhooks. Users must manually create new OGXServer CRs and migrate configuration.
+
+## Name Mapping
+
+| Component | Old | New |
+|-----------|-----|-----|
+| API Group | `llamastack.io` | `ogx.io` |
+| API Version | `v1alpha1` | `v1beta1` |
+| Kind | `LlamaStackDistribution` | `OGXServer` |
+| Plural | `llamastackdistributions` | `ogxservers` |
+| Short Name | `llsd` | `ogxs` |
+| Container Name | `llama-stack` | `ogx` |
+| App Label | `app: llama-stack` | `app: ogx` |
+| Managed-by | `llama-stack-operator` | `ogx-operator` |
+| Operator Namespace | `llama-stack-k8s-operator-system` | `ogx-k8s-operator-system` |
+| Watch Label | `llamastack.io/watch: "true"` | `ogx.io/watch: "true"` |
+| Mount Path | `/.llama` | `/.ogx` |
+| Leader Election ID | `81d5736e.llamastack.io` | `54e06e98.ogx.io` |
+
+### Status Field Changes
+
+| Old Path | New Path |
+|----------|----------|
+| `.status.version.llamaStackServerVersion` | `.status.version.serverVersion` |
+| `.status.routeURL` | `.status.externalURL` |
+
+### CLI Commands
+
+| Old | New |
+|-----|-----|
+| `kubectl get llsd` | `kubectl get ogxs` |
+| `kubectl get llamastackdistributions` | `kubectl get ogxservers` |
+
+## Spec Changes
+
+### Network Configuration
+
+Old (`spec.network`):
+```yaml
+spec:
+  network:
+    exposeRoute: true
+    allowedFrom:
+      namespaces: ["my-app"]
+      labels: ["team=frontend"]
+```
+
+New (`spec.network`):
+```yaml
+spec:
+  network:
+    externalAccess:
+      enabled: true
+    policy:
+      enabled: true
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: my-app
+            - namespaceSelector:
+                matchLabels:
+                  team: frontend
+          ports:
+            - protocol: TCP
+              port: 8321
+```
+
+### TLS Configuration
+
+Old (nested under `server.tlsConfig`):
+```yaml
+spec:
+  server:
+    tlsConfig:
+      enabled: true
+      secretName: my-tls-secret
+      caBundle:
+        configMapName: my-ca-bundle
+```
+
+New (server TLS under `network.tls`, outbound trust under `tls.trust`):
+```yaml
+spec:
+  network:
+    tls:
+      secretName: my-tls-secret
+  tls:
+    trust:
+      caCertificates:
+        - name: my-ca-bundle
+          key: ca-bundle.crt
+```
+
+### Workload Configuration
+
+Old (flat on spec):
+```yaml
+spec:
+  replicas: 2
+  server:
+    distribution:
+      name: starter
+    containerSpec:
+      env:
+        - name: MY_VAR
+          value: "hello"
+    storage:
+      size: "20Gi"
+```
+
+New (grouped under `spec.workload`):
+```yaml
+spec:
+  distribution:
+    name: starter
+  workload:
+    replicas: 2
+    storage:
+      size: "20Gi"
+    overrides:
+      env:
+        - name: MY_VAR
+          value: "hello"
+```
+
+### NetworkPolicy
+
+The legacy `AllowedFromSpec` and ConfigMap-based `enableNetworkPolicy` feature flag are replaced by `spec.network.policy` with native Kubernetes NetworkPolicy types:
+
+```yaml
+spec:
+  network:
+    policy:
+      enabled: true            # Per-CR toggle (replaces ConfigMap feature flag)
+      policyTypes:
+        - Ingress
+        - Egress
+      ingress:                 # Native K8s NetworkPolicyIngressRule
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: my-app
+          ports:
+            - protocol: TCP
+              port: 8321
+      egress:                  # Native K8s NetworkPolicyEgressRule
+        - to:
+            - ipBlock:
+                cidr: 10.0.0.0/8
+          ports:
+            - protocol: TCP
+              port: 443
+```
+
+To translate `enableNetworkPolicy: false` from the old ConfigMap, set `spec.network.policy.enabled: false` on the CR.
+
+### ConfigMap/Secret Watch Labels
+
+All referenced ConfigMaps and Secrets must have the `ogx.io/watch: "true"` label:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+  labels:
+    ogx.io/watch: "true"
+data:
+  config.yaml: |
+    ...
+```
+
+## Upgrade Steps
+
+### Step 1: Remove the Old LLS Operator
+
+**Via meta-operator:**
+```bash
+# Set component to Removed
+dsc.spec.components.lls = "Removed"
+```
+
+**Manual:**
+```bash
+# Delete the operator Deployment, ServiceAccount, and RBAC — but NOT the CRD.
+# Deleting the CRD cascade-deletes all CRs and their owned resources (data loss).
+kubectl -n llama-stack-k8s-operator-system delete deployment llama-stack-k8s-operator-controller-manager
+kubectl -n llama-stack-k8s-operator-system delete serviceaccount llama-stack-k8s-operator-controller-manager
+kubectl delete clusterrolebinding llama-stack-k8s-operator-manager-rolebinding
+kubectl delete clusterrole llama-stack-k8s-operator-manager-role
+```
+
+> **Warning:** Do NOT run `kubectl delete -f release/operator.yaml` — that file includes the CRD,
+> and deleting a CRD cascade-deletes all its CRs and their owned resources (PVCs, Deployments, etc.).
+
+The operand Deployments, CRD, and CRs remain after operator removal.
+
+### Step 2: Delete Orphaned Stateless Resources
+
+```bash
+kubectl delete deploy,networkpolicy,sa,rolebinding -l app.kubernetes.io/instance=<name>
+kubectl delete hpa,pdb -l app.kubernetes.io/instance=<name>
+```
+
+**Keep:** PVC (adopted in Step 4), and optionally Service + Ingress (adopted in Step 5).
+
+**Why:** After operator removal, orphaned resources have no active controller. The new operator's `patchResource` safety check skips resources it does not own, so it cannot update or replace them. NetworkPolicy is especially critical: the old policy's `podSelector` targets `app: llama-stack` which no longer matches the new `app: ogx` pods.
+
+### Step 3: Install the New OGX Operator
+
+**Via meta-operator:**
+```bash
+dsc.spec.components.ogx = "Managed"
+```
+
+**Manual:**
+```bash
+kubectl apply -f release/operator.yaml
+```
+
+### Step 4: Create OGXServer CR with Adopt-Storage Annotation
+
+Translate fields from the old LLSD CR into the new OGXServer spec, and include the adoption annotation:
+
+```yaml
+apiVersion: ogx.io/v1beta1
+kind: OGXServer
+metadata:
+  name: my-server
+  annotations:
+    ogx.io/adopt-storage: "<old-llsd-name>"
+spec:
+  distribution:
+    name: starter
+  workload:
+    replicas: 1
+    storage:
+      size: "20Gi"
+    overrides:
+      env:
+        - name: OLLAMA_INFERENCE_MODEL
+          value: "llama3.2:1b"
+        - name: OLLAMA_URL
+          value: "http://ollama-server-service.ollama-dist.svc.cluster.local:11434"
+```
+
+The operator adopts the orphaned PVC (strips old ownerRef, labels it for discovery) and creates a new Deployment that mounts the adopted PVC. The PVC intentionally has **no** ownerReference to the OGXServer — it survives CR deletion and must be cleaned up manually. Expect ~30-60s until the new pod is ready.
+
+> **Warning:** If multiple PVCs with the `ogx.io/adopted-from` label are found for the same instance, the controller sets an `AdoptionConfigInvalid` condition and stops reconciling (terminal error — no requeue). Remove the label from all but one PVC to resolve.
+
+### Step 5 (Optional): Adopt Networking
+
+Add the networking adoption annotation to preserve ClusterIP / external endpoint:
+
+```yaml
+metadata:
+  annotations:
+    ogx.io/adopt-storage: "<old-llsd-name>"
+    ogx.io/adopt-networking: "<old-llsd-name>"
+```
+
+The operator adopts the orphaned Service + Ingress, replaces Service selectors with new pod labels (`app: ogx`, `app.kubernetes.io/instance: <name>`), and sets ownerReferences.
+
+> **Note:** The OGXServer name **must differ** from the old LLSD name. Same-name adoption is rejected at admission time (webhook validation) to prevent resource naming conflicts.
+
+### Step 6: Clean Up Legacy Resources
+
+```bash
+kubectl delete crd llamastackdistributions.llamastack.io
+```
+
+## Verification
+
+```bash
+# Check the new CRD is registered
+kubectl get crd ogxservers.ogx.io
+
+# List OGXServer resources
+kubectl get ogxs
+
+# Check conditions for adoption status
+kubectl get ogxs my-server -o jsonpath='{.status.conditions}'
+
+# Verify the server is ready
+kubectl get ogxs my-server -o jsonpath='{.status.phase}'
+```
+
+## Rollback
+
+If you need to roll back:
+
+1. Remove the `ogx.io/adopt-storage` annotation from the OGXServer CR
+2. Delete the OGXServer CR
+3. Scale the old Deployment back up (it was scaled to zero, not deleted)
+4. Reinstall the old LLS operator
+5. Recreate the old LlamaStackDistribution CR
+
+## Adoption Annotations
+
+| Annotation / Label | Purpose |
+|------------|---------|
+| `ogx.io/adopt-storage` (annotation) | Triggers PVC adoption from the named legacy LLSD |
+| `ogx.io/adopt-networking` (annotation) | Triggers Service/Ingress adoption from the named legacy LLSD |
+| `ogx.io/adopted-from` (label) | Set on all adopted resources (PVC, Service, Ingress) for server-side filtering and discovery |
+| `ogx.io/adopted-at` (annotation) | Set on adopted resources with an RFC 3339 timestamp |
+
+These annotations are transitional and will be removed in a future release once migration is complete.
+
+**Constraints:**
+- The annotation value **must not** equal the OGXServer CR name (same-name adoption is rejected by the validating webhook).
+- The annotation value must be a valid DNS subdomain name (lowercase alphanumeric, `-`, max 253 chars).
+
+## NetworkPolicy Impact
+
+The label change from `app: llama-stack` to `app: ogx` affects all NetworkPolicy `podSelector` fields:
+
+**Old operator NetworkPolicy:**
+```yaml
+spec:
+  podSelector:
+    matchLabels:
+      app: llama-stack
+      app.kubernetes.io/instance: my-server
+```
+
+**New operator NetworkPolicy:**
+```yaml
+spec:
+  podSelector:
+    matchLabels:
+      app: ogx
+      app.kubernetes.io/instance: my-server
+```
+
+Any external NetworkPolicies targeting `app: llama-stack` must be updated to `app: ogx`.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -161,21 +161,21 @@ spec:
 
 To translate `enableNetworkPolicy: false` from the old ConfigMap, set `spec.network.policy.enabled: false` on the CR.
 
-### ConfigMap/Secret Watch Labels
+### ConfigMap/Secret Watch Labels and Namespace Scope
 
-All referenced ConfigMaps and Secrets must have the `ogx.io/watch: "true"` label:
+All referenced ConfigMaps and Secrets must have the `ogx.io/watch: "true"` label, and must be in the same namespace as the OGXServer CR:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: my-config
+  namespace: <ogx_server_cr_namespace>
   labels:
     ogx.io/watch: "true"
 data:
   config.yaml: |
     ...
-```
 
 ## Upgrade Steps
 
@@ -202,16 +202,19 @@ kubectl delete clusterrole llama-stack-k8s-operator-manager-role
 
 The operand Deployments, CRD, and CRs remain after operator removal.
 
-### Step 2: Delete Orphaned Stateless Resources
+### Step 2: Scale Down and Clean Up Orphaned Stateless Resources
+
+Scale the old deployment to zero (preserving it for rollback) and delete stateless resources that the new operator cannot adopt:
 
 ```bash
-kubectl delete deploy,networkpolicy,sa,rolebinding -l app.kubernetes.io/instance=<name>
+kubectl scale deployment <name> --replicas=0 -n <namespace>
+kubectl delete networkpolicy,sa,rolebinding -l app.kubernetes.io/instance=<name>
 kubectl delete hpa,pdb -l app.kubernetes.io/instance=<name>
 ```
 
-**Keep:** PVC (adopted in Step 4), and optionally Service + Ingress (adopted in Step 5).
+**Keep for now:** The old Deployment (scaled to 0), PVC, Service, Ingress, and the old LlamaStackDistribution CR all remain in place. This makes rollback straightforward — see the [Rollback](#rollback) section.
 
-**Why:** After operator removal, orphaned resources have no active controller. The new operator's `patchResource` safety check skips resources it does not own, so it cannot update or replace them. NetworkPolicy is especially critical: the old policy's `podSelector` targets `app: llama-stack` which no longer matches the new `app: ogx` pods.
+**Why clean up stateless resources?** After operator removal, orphaned resources have no active controller. The new operator's `patchResource` safety check skips resources it does not own, so it cannot update or replace them. NetworkPolicy is especially critical: the old policy's `podSelector` targets `app: llama-stack` which no longer matches the new `app: ogx` pods.
 
 ### Step 3: Install the New OGX Operator
 
@@ -225,17 +228,14 @@ dsc.spec.components.ogx = "Managed"
 kubectl apply -f release/operator.yaml
 ```
 
-### Step 4: Create OGXServer CR with Adopt-Storage Annotation
+### Step 4: Define OGXServer CR
 
-Translate fields from the old LLSD CR into the new OGXServer spec, and include the adoption annotation:
-
+Translate fields from the old LLSD CR into the new OGXServer spec
 ```yaml
 apiVersion: ogx.io/v1beta1
 kind: OGXServer
 metadata:
   name: my-server
-  annotations:
-    ogx.io/adopt-storage: "<old-llsd-name>"
 spec:
   distribution:
     name: starter
@@ -270,10 +270,33 @@ The operator adopts the orphaned Service + Ingress, replaces Service selectors w
 
 > **Note:** The OGXServer name **must differ** from the old LLSD name. Same-name adoption is rejected at admission time (webhook validation) to prevent resource naming conflicts.
 
-### Step 6: Clean Up Legacy Resources
+### Step 6: Verify and Clean Up Legacy Resources
+
+Once the new OGXServer is `Ready` and verified (see [Verification](#verification)), clean up legacy resources:
 
 ```bash
+# Delete the old LlamaStackDistribution CR (orphan dependents since we already cleaned them up)
+kubectl delete llamastackdistribution <old-llsd-name> -n <namespace> --cascade=orphan
+
+# Delete the old deployment (was scaled to 0 in Step 2)
+kubectl delete deployment <old-llsd-name> -n <namespace>
+
+# Delete the legacy CRD (safe only after all LlamaStackDistribution CRs are removed)
 kubectl delete crd llamastackdistributions.llamastack.io
+```
+
+If you chose **not** to adopt the old PVC (Step 4), delete it now:
+
+```bash
+kubectl delete pvc <old-llsd-name>-pvc -n <namespace>
+```
+
+If you chose **not** to adopt the old Service and Ingress/Route (Step 5), delete them now:
+
+```bash
+kubectl delete svc <old-llsd-name>-service -n <namespace>
+kubectl delete ingress <old-llsd-name> -n <namespace> --ignore-not-found
+kubectl delete route <old-llsd-name> -n <namespace> --ignore-not-found
 ```
 
 ## Verification
@@ -294,22 +317,23 @@ kubectl get ogxs my-server -o jsonpath='{.status.phase}'
 
 ## Rollback
 
-If you need to roll back:
+If you need to roll back before completing Step 6 (legacy cleanup):
 
-1. Remove the `ogx.io/adopt-storage` annotation from the OGXServer CR
-2. Delete the OGXServer CR
-3. Scale the old Deployment back up (it was scaled to zero, not deleted)
-4. Reinstall the old LLS operator
-5. Recreate the old LlamaStackDistribution CR
+1. Delete the OGXServer CR: `kubectl delete ogxserver my-server -n <namespace>`
+2. Scale the old Deployment back up: `kubectl scale deployment <old-llsd-name> --replicas=1 -n <namespace>`
+3. Reinstall the old LLS operator
+4. The old LlamaStackDistribution CR is still present and will be reconciled by the reinstalled operator
+
+If you already completed Step 6 (legacy resources deleted), you must recreate the old LlamaStackDistribution CR manually after reinstalling the old operator.
 
 ## Adoption Annotations
 
-| Annotation / Label | Purpose |
+The following annotations are set by the user on the OGXServer CR to trigger adoption:
+
+| Annotation | Purpose |
 |------------|---------|
-| `ogx.io/adopt-storage` (annotation) | Triggers PVC adoption from the named legacy LLSD |
-| `ogx.io/adopt-networking` (annotation) | Triggers Service/Ingress adoption from the named legacy LLSD |
-| `ogx.io/adopted-from` (label) | Set on all adopted resources (PVC, Service, Ingress) for server-side filtering and discovery |
-| `ogx.io/adopted-at` (annotation) | Set on adopted resources with an RFC 3339 timestamp |
+| `ogx.io/adopt-storage` | Triggers PVC adoption from the named legacy LLSD |
+| `ogx.io/adopt-networking` | Triggers Service/Ingress adoption from the named legacy LLSD |
 
 These annotations are transitional and will be removed in a future release once migration is complete.
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -176,6 +176,7 @@ metadata:
 data:
   config.yaml: |
     ...
+```
 
 ## Upgrade Steps
 
@@ -200,23 +201,9 @@ kubectl delete clusterrole llama-stack-k8s-operator-manager-role
 > **Warning:** Do NOT run `kubectl delete -f release/operator.yaml` — that file includes the CRD,
 > and deleting a CRD cascade-deletes all its CRs and their owned resources (PVCs, Deployments, etc.).
 
-The operand Deployments, CRD, and CRs remain after operator removal.
+The operand Deployments, CRD, and CRs remain after operator removal. The old workload keeps running — no downtime yet.
 
-### Step 2: Scale Down and Clean Up Orphaned Stateless Resources
-
-Scale the old deployment to zero (preserving it for rollback) and delete stateless resources that the new operator cannot adopt:
-
-```bash
-kubectl scale deployment <name> --replicas=0 -n <namespace>
-kubectl delete networkpolicy,sa,rolebinding -l app.kubernetes.io/instance=<name>
-kubectl delete hpa,pdb -l app.kubernetes.io/instance=<name>
-```
-
-**Keep for now:** The old Deployment (scaled to 0), PVC, Service, Ingress, and the old LlamaStackDistribution CR all remain in place. This makes rollback straightforward — see the [Rollback](#rollback) section.
-
-**Why clean up stateless resources?** After operator removal, orphaned resources have no active controller. The new operator's `patchResource` safety check skips resources it does not own, so it cannot update or replace them. NetworkPolicy is especially critical: the old policy's `podSelector` targets `app: llama-stack` which no longer matches the new `app: ogx` pods.
-
-### Step 3: Install the New OGX Operator
+### Step 2: Install the New OGX Operator
 
 **Via meta-operator:**
 ```bash
@@ -228,9 +215,10 @@ dsc.spec.components.ogx = "Managed"
 kubectl apply -f release/operator.yaml
 ```
 
-### Step 4: Define OGXServer CR
+### Step 3: Define the OGXServer CR
 
-Translate fields from the old LLSD CR into the new OGXServer spec
+Translate fields from the old LLSD CR into the new OGXServer spec. See [Spec Changes](#spec-changes) above for the field mapping.
+
 ```yaml
 apiVersion: ogx.io/v1beta1
 kind: OGXServer
@@ -251,13 +239,25 @@ spec:
           value: "http://ollama-server-service.ollama-dist.svc.cluster.local:11434"
 ```
 
-The operator adopts the orphaned PVC (strips old ownerRef, labels it for discovery) and creates a new Deployment that mounts the adopted PVC. The PVC intentionally has **no** ownerReference to the OGXServer — it survives CR deletion and must be cleaned up manually. Expect ~30-60s until the new pod is ready.
+> **Note:** The OGXServer name **must differ** from the old LLSD name. Same-name adoption is rejected by the validating webhook to prevent resource naming conflicts.
 
-> **Warning:** If multiple PVCs with the `ogx.io/adopted-from` label are found for the same instance, the controller sets an `AdoptionConfigInvalid` condition and stops reconciling (terminal error — no requeue). Remove the label from all but one PVC to resolve.
+#### Adopting Existing PVC (Optional)
 
-### Step 5 (Optional): Adopt Networking
+To preserve existing data by adopting the PVC from the old LlamaStackDistribution:
 
-Add the networking adoption annotation to preserve ClusterIP / external endpoint:
+```yaml
+metadata:
+  annotations:
+    ogx.io/adopt-storage: "<old-llsd-name>"
+```
+
+The operator strips the old ownerRef from the PVC and labels it for discovery. The adopted PVC intentionally has **no** ownerReference to the OGXServer — it survives CR deletion and must be cleaned up manually.
+
+> **Warning:** If multiple PVCs with matching adoption labels are found for the same instance, the controller sets an `AdoptionConfigInvalid` condition and stops reconciling. Remove the conflicting label to resolve.
+
+#### Adopting Existing Service and Ingress (Optional)
+
+To preserve ClusterIP / external endpoints:
 
 ```yaml
 metadata:
@@ -268,38 +268,15 @@ metadata:
 
 The operator adopts the orphaned Service + Ingress, replaces Service selectors with new pod labels (`app: ogx`, `app.kubernetes.io/instance: <name>`), and sets ownerReferences.
 
-> **Note:** The OGXServer name **must differ** from the old LLSD name. Same-name adoption is rejected at admission time (webhook validation) to prevent resource naming conflicts.
-
-### Step 6: Verify and Clean Up Legacy Resources
-
-Once the new OGXServer is `Ready` and verified (see [Verification](#verification)), clean up legacy resources:
+### Step 4: Apply the OGXServer CR
 
 ```bash
-# Delete the old LlamaStackDistribution CR (orphan dependents since we already cleaned them up)
-kubectl delete llamastackdistribution <old-llsd-name> -n <namespace> --cascade=orphan
-
-# Delete the old deployment (was scaled to 0 in Step 2)
-kubectl delete deployment <old-llsd-name> -n <namespace>
-
-# Delete the legacy CRD (safe only after all LlamaStackDistribution CRs are removed)
-kubectl delete crd llamastackdistributions.llamastack.io
+kubectl apply -f ogxserver.yaml
 ```
 
-If you chose **not** to adopt the old PVC (Step 4), delete it now:
+Expect ~30–60s until the new pod is ready.
 
-```bash
-kubectl delete pvc <old-llsd-name>-pvc -n <namespace>
-```
-
-If you chose **not** to adopt the old Service and Ingress/Route (Step 5), delete them now:
-
-```bash
-kubectl delete svc <old-llsd-name>-service -n <namespace>
-kubectl delete ingress <old-llsd-name> -n <namespace> --ignore-not-found
-kubectl delete route <old-llsd-name> -n <namespace> --ignore-not-found
-```
-
-## Verification
+### Step 5: Verify
 
 ```bash
 # Check the new CRD is registered
@@ -315,31 +292,49 @@ kubectl get ogxs my-server -o jsonpath='{.status.conditions}'
 kubectl get ogxs my-server -o jsonpath='{.status.phase}'
 ```
 
+Wait until the OGXServer phase is `Ready` before proceeding to cleanup.
+
+### Step 6: Clean Up Legacy Resources
+
+Once the new OGXServer is verified healthy, remove legacy resources.
+
+Delete the old LlamaStackDistribution CR. Kubernetes will cascade-delete its owned resources (Deployment, NetworkPolicy, ServiceAccount, RoleBinding, HPA, PDB):
+
+```bash
+kubectl delete llamastackdistribution <old-llsd-name> -n <namespace>
+```
+
+If you adopted the PVC or Service/Ingress (Step 3), those resources now have new ownerRefs and are **not** affected by this deletion.
+
+If you chose **not** to adopt the old PVC, delete it manually:
+
+```bash
+kubectl delete pvc <old-llsd-name>-pvc -n <namespace>
+```
+
+If you chose **not** to adopt the old Service and Ingress/Route, delete them manually:
+
+```bash
+kubectl delete svc <old-llsd-name>-service -n <namespace>
+kubectl delete ingress <old-llsd-name> -n <namespace> --ignore-not-found
+kubectl delete route <old-llsd-name> -n <namespace> --ignore-not-found
+```
+
+Finally, once all LlamaStackDistribution CRs have been removed, delete the legacy CRD:
+
+```bash
+kubectl delete crd llamastackdistributions.llamastack.io
+```
+
 ## Rollback
 
-If you need to roll back before completing Step 6 (legacy cleanup):
+If something goes wrong before completing Step 6 (legacy cleanup), rollback is straightforward because the old resources are still in place:
 
 1. Delete the OGXServer CR: `kubectl delete ogxserver my-server -n <namespace>`
-2. Scale the old Deployment back up: `kubectl scale deployment <old-llsd-name> --replicas=1 -n <namespace>`
-3. Reinstall the old LLS operator
-4. The old LlamaStackDistribution CR is still present and will be reconciled by the reinstalled operator
+2. Reinstall the old LLS operator
+3. The old LlamaStackDistribution CR is still present and will be reconciled by the reinstalled operator
 
 If you already completed Step 6 (legacy resources deleted), you must recreate the old LlamaStackDistribution CR manually after reinstalling the old operator.
-
-## Adoption Annotations
-
-The following annotations are set by the user on the OGXServer CR to trigger adoption:
-
-| Annotation | Purpose |
-|------------|---------|
-| `ogx.io/adopt-storage` | Triggers PVC adoption from the named legacy LLSD |
-| `ogx.io/adopt-networking` | Triggers Service/Ingress adoption from the named legacy LLSD |
-
-These annotations are transitional and will be removed in a future release once migration is complete.
-
-**Constraints:**
-- The annotation value **must not** equal the OGXServer CR name (same-name adoption is rejected by the validating webhook).
-- The annotation value must be a valid DNS subdomain name (lowercase alphanumeric, `-`, max 253 chars).
 
 ## NetworkPolicy Impact
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -14,7 +14,7 @@ This is a **breaking change**. There is no coexistence period and no conversion 
 | API Version | `v1alpha1` | `v1beta1` |
 | Kind | `LlamaStackDistribution` | `OGXServer` |
 | Plural | `llamastackdistributions` | `ogxservers` |
-| Short Name | `llsd` | `ogxs` |
+| Short Name | `llsd` | `ogxserver` |
 | Container Name | `llama-stack` | `ogx` |
 | App Label | `app: llama-stack` | `app: ogx` |
 | Managed-by | `llama-stack-operator` | `ogx-operator` |
@@ -34,7 +34,7 @@ This is a **breaking change**. There is no coexistence period and no conversion 
 
 | Old | New |
 |-----|-----|
-| `kubectl get llsd` | `kubectl get ogxs` |
+| `kubectl get llsd` | `kubectl get ogxserver` |
 | `kubectl get llamastackdistributions` | `kubectl get ogxservers` |
 
 ## Spec Changes
@@ -283,13 +283,13 @@ Expect ~30–60s until the new pod is ready.
 kubectl get crd ogxservers.ogx.io
 
 # List OGXServer resources
-kubectl get ogxs
+kubectl get ogxserver
 
 # Check conditions for adoption status
-kubectl get ogxs my-server -o jsonpath='{.status.conditions}'
+kubectl get ogxserver my-server -o jsonpath='{.status.conditions}'
 
 # Verify the server is ready
-kubectl get ogxs my-server -o jsonpath='{.status.phase}'
+kubectl get ogxserver my-server -o jsonpath='{.status.phase}'
 ```
 
 Wait until the OGXServer phase is `Ready` before proceeding to cleanup.

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -47,8 +47,8 @@ func TestApplyDeploymentPreservesSelector(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "llamastack",
-							Image: "quay.io/llamastack/llama-stack-k8s-operator:v0.0.1",
+							Name:  "ogx",
+							Image: "quay.io/ogx-ai/ogx-k8s-operator:v0.0.1",
 						},
 					},
 				},
@@ -84,8 +84,8 @@ func TestApplyDeploymentPreservesSelector(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "llamastack",
-							Image: "quay.io/llamastack/llama-stack-k8s-operator:v0.0.2",
+							Name:  "ogx",
+							Image: "quay.io/ogx-ai/ogx-k8s-operator:v0.0.2",
 						},
 					},
 				},
@@ -104,7 +104,7 @@ func TestApplyDeploymentPreservesSelector(t *testing.T) {
 	require.Equal(t, "initial", foundDeployment.Spec.Selector.MatchLabels["app"])
 
 	// And the other updates should be applied
-	require.Equal(t, "quay.io/llamastack/llama-stack-k8s-operator:v0.0.2", foundDeployment.Spec.Template.Spec.Containers[0].Image)
+	require.Equal(t, "quay.io/ogx-ai/ogx-k8s-operator:v0.0.2", foundDeployment.Spec.Template.Spec.Containers[0].Image)
 }
 
 func TestApplyDeploymentDoesNotOverrideHPAScale(t *testing.T) {
@@ -152,8 +152,8 @@ func TestApplyDeploymentDoesNotOverrideHPAScale(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "llamastack",
-							Image: "quay.io/llamastack/llama-stack-k8s-operator:v0.0.1",
+							Name:  "ogx",
+							Image: "quay.io/ogx-ai/ogx-k8s-operator:v0.0.1",
 						},
 					},
 				},

--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -51,6 +51,11 @@ func setupApplyResourcesTest(t *testing.T, ownerName string) (context.Context, s
 			Name:      ownerName,
 			Namespace: testNs,
 		},
+		Spec: ogxiov1beta1.OGXServerSpec{
+			Distribution: ogxiov1beta1.DistributionSpec{
+				Name: "starter",
+			},
+		},
 	}
 	ownerGVK := owner.GroupVersionKind()
 
@@ -320,6 +325,11 @@ func TestApplyResources(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-owner-other",
 				Namespace: testNs,
+			},
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{
+					Name: "starter",
+				},
 			},
 		}
 		require.NoError(t, k8sClient.Create(ctx, ownerOther))

--- a/pkg/deploy/plugins/field_mutator_test.go
+++ b/pkg/deploy/plugins/field_mutator_test.go
@@ -246,7 +246,7 @@ func TestTransform(t *testing.T) {
 			transformer: CreateFieldMutator(FieldMutatorConfig{
 				Mappings: []FieldMapping{
 					{TargetKind: "Service", TargetField: "/spec/selector/app.kubernetes.io~1instance", SourceValue: "dynamic-instance-name", CreateIfNotExists: true},
-					{TargetKind: "Service", TargetField: "/spec/selector/app.kubernetes.io~1name", SourceValue: "llamastack", CreateIfNotExists: true},
+					{TargetKind: "Service", TargetField: "/spec/selector/app.kubernetes.io~1name", SourceValue: "ogx", CreateIfNotExists: true},
 				},
 			}),
 			initialResources: []*resource.Resource{
@@ -261,7 +261,7 @@ func TestTransform(t *testing.T) {
 				"my-service": {
 					"selector": map[string]any{
 						"app.kubernetes.io/instance": "dynamic-instance-name",
-						"app.kubernetes.io/name":     "llamastack",
+						"app.kubernetes.io/name":     "ogx",
 						"app":                        "other-label",
 					},
 				},

--- a/pkg/deploy/suite_test.go
+++ b/pkg/deploy/suite_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	llamav1alpha1 "github.com/ogx-ai/ogx-k8s-operator/api/v1alpha1"
 	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -39,14 +38,9 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	err = llamav1alpha1.AddToScheme(scheme.Scheme)
-	if err != nil {
-		logf.Log.Error(err, "failed to add scheme")
-		os.Exit(1)
-	}
 	err = ogxiov1beta1.AddToScheme(scheme.Scheme)
 	if err != nil {
-		logf.Log.Error(err, "failed to add v1beta1 scheme")
+		logf.Log.Error(err, "failed to add scheme")
 		os.Exit(1)
 	}
 

--- a/release/operator-openshift.yaml
+++ b/release/operator-openshift.yaml
@@ -20,8 +20,6 @@ spec:
     kind: OGXServer
     listKind: OGXServerList
     plural: ogxservers
-    shortNames:
-    - ogxs
     singular: ogxserver
   scope: Namespaced
   versions:
@@ -6706,7 +6704,7 @@ metadata:
     app.kubernetes.io/name: ogx-k8s-operator
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-  name: ogx-k8s-operator-ogxs-editor-role
+  name: ogx-k8s-operator-ogxserver-editor-role
 rules:
 - apiGroups:
   - ogx.io
@@ -6733,7 +6731,7 @@ metadata:
   labels:
     app.kubernetes.io/name: ogx-k8s-operator
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-  name: ogx-k8s-operator-ogxs-viewer-role
+  name: ogx-k8s-operator-ogxserver-viewer-role
 rules:
 - apiGroups:
   - ogx.io

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -21,8 +21,6 @@ spec:
     kind: OGXServer
     listKind: OGXServerList
     plural: ogxservers
-    shortNames:
-    - ogxs
     singular: ogxserver
   scope: Namespaced
   versions:
@@ -6707,7 +6705,7 @@ metadata:
     app.kubernetes.io/name: ogx-k8s-operator
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-  name: ogx-k8s-operator-ogxs-editor-role
+  name: ogx-k8s-operator-ogxserver-editor-role
 rules:
 - apiGroups:
   - ogx.io
@@ -6734,7 +6732,7 @@ metadata:
   labels:
     app.kubernetes.io/name: ogx-k8s-operator
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-  name: ogx-k8s-operator-ogxs-viewer-role
+  name: ogx-k8s-operator-ogxserver-viewer-role
 rules:
 - apiGroups:
   - ogx.io

--- a/specs/003-ogx-rename/deferred-items.md
+++ b/specs/003-ogx-rename/deferred-items.md
@@ -1,0 +1,49 @@
+# Deferred Items: OGX Rename
+
+Items deferred from the initial rename PRs per FR-006. These use legacy naming intentionally and will be addressed in follow-up work.
+
+## Container Registry URLs
+
+The following container registry references still use the old naming convention. These depend on external infrastructure (registry org creation, image migration) and will be updated once the `ogx-ai` Quay.io org and image pipeline are established:
+
+- `quay.io/llamastack/` image references in `distributions.json`
+- Hardcoded fallback images in `pkg/cluster/cluster.go`
+- CI workflow image push targets (`.github/workflows/build-image.yml`, `release-image.yml`)
+
+## Git Organization URLs
+
+The Go module path has been updated to `github.com/ogx-ai/ogx-k8s-operator`, but the following depend on the GitHub org existing with the repo:
+
+- `go.mod` module path (currently updated but repo not yet migrated)
+- Import paths across all Go files (updated to new module path)
+- GitHub Actions workflow references to the repo
+
+## Upstream Runtime Contracts
+
+Per the spec, the following upstream runtime contract strings are preserved as-is because upstream is still stabilizing them:
+
+- `LLAMA_STACK_CONFIG` environment variable
+- `/etc/llama-stack/config.yaml` config mount path
+- `/.llama` legacy upstream data directory (operator uses `/.ogx` for its own mount)
+- `llama_stack.core.server.server` Python module entrypoint
+
+These will be updated once the upstream `llama-stack` Python package completes its own rename.
+
+## Adoption Annotations / Labels
+
+The following annotations and labels are transitional and will be removed once migration tooling is no longer needed:
+
+- `ogx.io/adopt-storage` (annotation on OGXServer CR)
+- `ogx.io/adopt-networking` (annotation on OGXServer CR)
+- `ogx.io/adopted-from` (label on adopted PVC/Service/Ingress)
+- `ogx.io/adopted-at` (annotation on adopted resources)
+
+Target removal: 2 minor releases after adoption feature ships.
+
+## RBAC Markers
+
+Transitional RBAC permissions in `controllers/kubebuilder_rbac.go` for legacy resource access:
+
+- Pods (`list`) — for checking termination status during adoption scale-down
+
+These will be removed alongside the adoption annotations.

--- a/specs/003-ogx-rename/plan.md
+++ b/specs/003-ogx-rename/plan.md
@@ -64,8 +64,8 @@ controllers/
 config/
 ├── crd/bases/ogx.io_ogxservers.yaml   # REGENERATE
 ├── crd/patches/cainjection_in_ogxservers.yaml  # RENAME
-├── rbac/ogxs_editor_role.yaml     # RENAME from llsd_editor_role.yaml
-├── rbac/ogxs_viewer_role.yaml     # RENAME from llsd_viewer_role.yaml
+├── rbac/ogxserver_editor_role.yaml     # RENAME from llsd_editor_role.yaml
+├── rbac/ogxserver_viewer_role.yaml     # RENAME from llsd_viewer_role.yaml
 ├── samples/_v1beta1_ogxserver.yaml  # RENAME + restructure to new schema
 └── samples/example-*.yaml         # MODIFY: new apiVersion, Kind, spec shape
 ```
@@ -216,5 +216,5 @@ Scaling old Deployment to zero (not deleting) preserves a rollback path: remove 
 - Clean-install startup time unchanged (SC-002)
 - Migration guide enables unassisted migration (SC-003)
 - No residual legacy naming in operator-owned artifacts (SC-005)
-- `kubectl get ogxs` returns new resources (SC-006)
+- `kubectl get ogxserver` returns new resources (SC-006)
 - PVC adoption downtime under 90 seconds (SC-009)

--- a/specs/003-ogx-rename/research.md
+++ b/specs/003-ogx-rename/research.md
@@ -25,9 +25,10 @@
 
 ### D-003: New Short Name
 
-- **Decision**: `ogxs`
-- **Rationale**: Follows the pattern of `{kind-abbreviation}` short names. `ogx` alone could conflict with future resource types in the same API group.
+- **Decision**: `ogxserver`
+- **Rationale**: Matches the singular resource name, which is the most intuitive short name for users. Avoids the ambiguity of an abbreviation.
 - **Alternatives considered**:
+  - `ogxs` — shorter but less intuitive than the singular form
   - `ogx` — simpler but may collide if the API group later adds more Kinds
 
 ### D-004: New Resource Plural

--- a/specs/003-ogx-rename/tasks.md
+++ b/specs/003-ogx-rename/tasks.md
@@ -57,7 +57,7 @@ This is a **breaking change**. The old `LlamaStackDistribution` CRD (`llamastack
   - `OGXServerSpec` — `distribution`, `providers`, `resources`, `storage`, `disabledAPIs` (renamed from `disabled`, Enum: agents/inference/tool_runtime/vector_io), **`network`**, **`caBundle`** (top-level), `workload`, `overrideConfig` (CEL: `providers`/`resources`/`storage`/`disabledAPIs` mutually exclusive with `overrideConfig`; cross-field disabled+providers conflict validation)
   - `OGXServerPhase` — `Pending`, `Initializing`, `Ready`, `Failed`, `Terminating`
   - Status types: `ProviderHealthStatus`, `ProviderInfo`, `DistributionConfig`, `VersionInfo` (with `ServerVersion` not `LlamaStackServerVersion`), `ResolvedDistributionStatus` (`Image`, `ConfigSource`, `ConfigHash`), `ConfigGenerationStatus` (`ObservedGeneration`, `ConfigMapName`, `GeneratedAt`, `ProviderCount`, `ResourceCount`, `ConfigVersion`), `OGXServerStatus` (with `ExternalURL` replacing `RouteURL`, pointer `*ResolvedDistributionStatus`, pointer `*ConfigGenerationStatus`)
-  - Root: `OGXServer`, `OGXServerList` with kubebuilder markers (`shortName=ogxs`, printer columns including Distribution/Config/Providers at priority=1, subresource:status)
+  - Root: `OGXServer`, `OGXServerList` with kubebuilder markers (`shortName=ogxserver`, printer columns including Distribution/Config/Providers at priority=1, subresource:status)
   - `init()` registering types with SchemeBuilder
 - [ ] T003a Add validating admission webhook for OGXServer that enforces constraints CEL markers cannot express: distribution name validation against embedded registry, cross-slice provider ID uniqueness (global, not per-slice), and model provider reference validation
 - [ ] T004 Add adoption annotation constants and helpers to `api/v1beta1/ogxserver_types.go`:
@@ -83,8 +83,8 @@ This is a **breaking change**. The old `LlamaStackDistribution` CRD (`llamastack
 
 - [ ] T011 Update `config/crd/kustomization.yaml`: base path to `ogx.io_ogxservers.yaml`, update patch references
 - [ ] T012 Rename `config/crd/patches/cainjection_in_llamastackdistributions.yaml` → `config/crd/patches/cainjection_in_ogxservers.yaml` and update content
-- [ ] T013 Rename `config/rbac/llsd_editor_role.yaml` → `config/rbac/ogxs_editor_role.yaml`, update role name and API group
-- [ ] T014 Rename `config/rbac/llsd_viewer_role.yaml` → `config/rbac/ogxs_viewer_role.yaml`, update role name and API group
+- [ ] T013 Rename `config/rbac/llsd_editor_role.yaml` → `config/rbac/ogxserver_editor_role.yaml`, update role name and API group
+- [ ] T014 Rename `config/rbac/llsd_viewer_role.yaml` → `config/rbac/ogxserver_viewer_role.yaml`, update role name and API group
 - [ ] T015 Update `config/default/kustomization.yaml`: namespace to `ogx-k8s-operator-system`, namePrefix to `ogx-k8s-operator-`, labels to `app.kubernetes.io/name: ogx-k8s-operator`
 - [ ] T016 Update `config/default/manager_labels_patch.yaml`: label values
 - [ ] T017 Update `config/manager/manager.yaml`, `config/manager/pdb.yaml`: label values
@@ -242,7 +242,7 @@ This is a **breaking change**. The old `LlamaStackDistribution` CRD (`llamastack
     5. (Optional) Add `ogx.io/adopt-networking` annotation
     6. Clean up: `kubectl delete crd llamastackdistributions.llamastack.io`
   - NetworkPolicy impact explanation (old `app: llama-stack` selector vs new `app: ogx`)
-  - Verification commands (`kubectl get ogxs`, check conditions, check events)
+  - Verification commands (`kubectl get ogxserver`, check conditions, check events)
   - Rollback section
   - Deprecation notice for adoption annotations (future removal target)
 

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ogx-ai/ogx-k8s-operator/api/v1alpha1"
+	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -22,55 +22,55 @@ import (
 )
 
 // runCreationTestsForDistribution runs creation tests for a specific distribution type.
-func runCreationTestsForDistribution(t *testing.T, distType string) *v1alpha1.LlamaStackDistribution {
+func runCreationTestsForDistribution(t *testing.T, distType string) *ogxiov1beta1.OGXServer {
 	t.Helper()
 	if TestOpts.SkipCreation {
 		t.Skip("Skipping creation test suite")
 	}
 
-	var llsdistributionCR *v1alpha1.LlamaStackDistribution
+	var ogxServer *ogxiov1beta1.OGXServer
 
-	t.Run("should create LlamaStackDistribution", func(t *testing.T) {
-		llsdistributionCR = testCreateDistributionForType(t, distType)
+	t.Run("should create OGXServer", func(t *testing.T) {
+		ogxServer = testCreateServerForType(t, distType)
 	})
 
 	t.Run("should create PVC if storage is configured", func(t *testing.T) {
-		testPVCConfiguration(t, llsdistributionCR)
+		testPVCConfiguration(t, ogxServer)
 	})
 
 	t.Run("should handle direct deployment updates", func(t *testing.T) {
-		testDirectDeploymentUpdates(t, llsdistributionCR)
+		testDirectDeploymentUpdates(t, ogxServer)
 	})
 
 	t.Run("should check health status", func(t *testing.T) {
-		testHealthStatus(t, llsdistributionCR)
+		testHealthStatus(t, ogxServer)
 	})
 
 	t.Run("should update deployment through CR", func(t *testing.T) {
-		testCRDeploymentUpdate(t, llsdistributionCR)
+		testCRDeploymentUpdate(t, ogxServer)
 	})
 
 	t.Run("should update distribution status", func(t *testing.T) {
-		testDistributionStatus(t, llsdistributionCR)
+		testDistributionStatus(t, ogxServer)
 	})
 
-	t.Run("should use custom ServiceAccount from PodOverrides", func(t *testing.T) {
-		testServiceAccountOverride(t, llsdistributionCR)
+	t.Run("should use custom ServiceAccount from workload overrides", func(t *testing.T) {
+		testServiceAccountOverride(t, ogxServer)
 	})
 
 	t.Run("should apply image mapping overrides from ConfigMap", func(t *testing.T) {
-		testImageMappingOverrides(t, llsdistributionCR)
+		testImageMappingOverrides(t, ogxServer)
 	})
 
-	return llsdistributionCR
+	return ogxServer
 }
 
-func testCreateDistributionForType(t *testing.T, distType string) *v1alpha1.LlamaStackDistribution {
+func testCreateServerForType(t *testing.T, distType string) *ogxiov1beta1.OGXServer {
 	t.Helper()
-	// Create test namespace
+
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "llama-stack-test",
+			Name: "ogx-test",
 		},
 	}
 	err := TestEnv.Client.Create(TestEnv.Ctx, ns)
@@ -78,56 +78,51 @@ func testCreateDistributionForType(t *testing.T, distType string) *v1alpha1.Llam
 		require.NoError(t, err)
 	}
 
-	// Get sample CR for the specific distribution type
-	llsdistributionCR := GetSampleCRForDistribution(t, distType)
-	llsdistributionCR.Namespace = ns.Name
+	ogxServer := GetSampleCRForDistribution(t, distType)
+	ogxServer.Namespace = ns.Name
 
-	t.Logf("Creating %s distribution with name: %s", distType, llsdistributionCR.Name)
+	t.Logf("Creating %s distribution with name: %s", distType, ogxServer.Name)
 
-	err = TestEnv.Client.Create(TestEnv.Ctx, llsdistributionCR)
+	err = TestEnv.Client.Create(TestEnv.Ctx, ogxServer)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		require.NoError(t, err)
 	}
 
-	// Wait for deployment to be ready
 	err = EnsureResourceReady(t, TestEnv, schema.GroupVersionKind{
 		Group:   "apps",
 		Version: "v1",
 		Kind:    "Deployment",
-	}, llsdistributionCR.Name, ns.Name, ResourceReadyTimeout, isDeploymentReady)
+	}, ogxServer.Name, ns.Name, ResourceReadyTimeout, isDeploymentReady)
 	require.NoError(t, err)
 
-	// Wait for pods to be running and ready
-	err = WaitForPodsReady(t, TestEnv, ns.Name, llsdistributionCR.Name, ResourceReadyTimeout)
+	err = WaitForPodsReady(t, TestEnv, ns.Name, ogxServer.Name, ResourceReadyTimeout)
 	require.NoError(t, err, "Pods should be running and ready")
 
-	// Verify service is created
 	err = EnsureResourceReady(t, TestEnv, schema.GroupVersionKind{
 		Group:   "",
 		Version: "v1",
 		Kind:    "Service",
-	}, llsdistributionCR.Name+"-service", ns.Name, ResourceReadyTimeout, func(u *unstructured.Unstructured) bool {
-		// Check if the service has a valid spec and status
+	}, ogxServer.Name+"-service", ns.Name, ResourceReadyTimeout, func(u *unstructured.Unstructured) bool {
 		spec, specFound, _ := unstructured.NestedMap(u.Object, "spec")
 		status, statusFound, _ := unstructured.NestedMap(u.Object, "status")
 		return specFound && statusFound && spec != nil && status != nil
 	})
-	requireNoErrorWithDebugging(t, TestEnv, err, "Service readiness check failed", llsdistributionCR.Namespace, llsdistributionCR.Name)
+	requireNoErrorWithDebugging(t, TestEnv, err, "Service readiness check failed", ogxServer.Namespace, ogxServer.Name)
 
-	return llsdistributionCR
+	return ogxServer
 }
 
-func testDirectDeploymentUpdates(t *testing.T, distribution *v1alpha1.LlamaStackDistribution) {
+func testDirectDeploymentUpdates(t *testing.T, server *ogxiov1beta1.OGXServer) {
 	t.Helper()
 
-	if distribution.Spec.Server.Autoscaling != nil && distribution.Spec.Server.Autoscaling.MaxReplicas > 0 {
+	if server.Spec.Workload != nil && server.Spec.Workload.Autoscaling != nil && server.Spec.Workload.Autoscaling.MaxReplicas > 0 {
 		t.Skip("Skipping direct deployment update healing test when autoscaling is enabled")
 	}
-	// Get the deployment
+
 	deployment := &appsv1.Deployment{}
 	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
-		Namespace: distribution.Namespace,
-		Name:      distribution.Name,
+		Namespace: server.Namespace,
+		Name:      server.Name,
 	}, deployment)
 	require.NoError(t, err)
 
@@ -136,47 +131,43 @@ func testDirectDeploymentUpdates(t *testing.T, distribution *v1alpha1.LlamaStack
 	err = TestEnv.Client.Update(TestEnv.Ctx, deployment)
 	require.NoError(t, err)
 
-	// Wait for operator to reconcile
 	time.Sleep(5 * time.Second)
 
-	// Verify deployment is reverted to original state
 	err = TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
-		Namespace: distribution.Namespace,
-		Name:      distribution.Name,
+		Namespace: server.Namespace,
+		Name:      server.Name,
 	}, deployment)
 	require.NoError(t, err)
 	require.Equal(t, originalReplicas, *deployment.Spec.Replicas, "Deployment should be reverted to original state")
 }
 
-func testCRDeploymentUpdate(t *testing.T, distribution *v1alpha1.LlamaStackDistribution) {
+func testCRDeploymentUpdate(t *testing.T, server *ogxiov1beta1.OGXServer) {
 	t.Helper()
-	// Update CR
+
 	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
-		Namespace: distribution.Namespace,
-		Name:      distribution.Name,
-	}, distribution)
+		Namespace: server.Namespace,
+		Name:      server.Name,
+	}, server)
 	require.NoError(t, err)
 
-	// Skip scaling test if PVC with ReadWriteOnce is used
-	// Most cloud providers (AWS EBS, Azure Disk, GCE PD) only support ReadWriteOnce for block storage
-	// ReadWriteMany requires network file systems (NFS, CephFS, etc.) which may not be available
-	if distribution.Spec.Server.Storage != nil {
+	if server.Spec.Workload != nil && server.Spec.Workload.Storage != nil {
 		t.Log("Skipping replica scaling test - PVC with ReadWriteOnce can only be attached to one pod at a time")
-		t.Log("To enable replica scaling with persistent storage, configure a StorageClass that supports ReadWriteMany")
 		return
 	}
 
-	// Update replicas
-	distribution.Spec.Replicas = 2
-	err = TestEnv.Client.Update(TestEnv.Ctx, distribution)
+	replicas := int32(2)
+	if server.Spec.Workload == nil {
+		server.Spec.Workload = &ogxiov1beta1.WorkloadSpec{}
+	}
+	server.Spec.Workload.Replicas = &replicas
+	err = TestEnv.Client.Update(TestEnv.Ctx, server)
 	require.NoError(t, err)
 
-	// Wait for deployment to be updated and ready with new replicas
 	err = EnsureResourceReady(t, TestEnv, schema.GroupVersionKind{
 		Group:   "apps",
 		Version: "v1",
 		Kind:    "Deployment",
-	}, distribution.Name, distribution.Namespace, ResourceReadyTimeout, func(u *unstructured.Unstructured) bool {
+	}, server.Name, server.Namespace, ResourceReadyTimeout, func(u *unstructured.Unstructured) bool {
 		availableReplicas, found, nestedErr := unstructured.NestedInt64(u.Object, "status", "availableReplicas")
 		if !found || nestedErr != nil {
 			return false
@@ -185,155 +176,144 @@ func testCRDeploymentUpdate(t *testing.T, distribution *v1alpha1.LlamaStackDistr
 	})
 	require.NoError(t, err, "Failed to wait for deployment to update replicas")
 
-	// Verify deployment is updated
 	deployment := &appsv1.Deployment{}
 	err = TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
-		Namespace: distribution.Namespace,
-		Name:      distribution.Name,
+		Namespace: server.Namespace,
+		Name:      server.Name,
 	}, deployment)
 	require.NoError(t, err)
 	require.Equal(t, int32(2), deployment.Status.AvailableReplicas, "Deployment should have 2 available replicas")
 }
 
-func testHealthStatus(t *testing.T, distribution *v1alpha1.LlamaStackDistribution) {
+func testHealthStatus(t *testing.T, server *ogxiov1beta1.OGXServer) {
 	t.Helper()
-	// Wait for status to be updated with a longer interval to avoid rate limiting
+
 	err := wait.PollUntilContextTimeout(TestEnv.Ctx, 1*time.Minute, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
-		// Get the latest state of the distribution
-		updatedDistribution := &v1alpha1.LlamaStackDistribution{}
+		updated := &ogxiov1beta1.OGXServer{}
 		err := TestEnv.Client.Get(ctx, client.ObjectKey{
-			Namespace: distribution.Namespace,
-			Name:      distribution.Name,
-		}, updatedDistribution)
+			Namespace: server.Namespace,
+			Name:      server.Name,
+		}, updated)
 		if err != nil {
 			return false, err
 		}
-		return updatedDistribution.Status.Phase == v1alpha1.LlamaStackDistributionPhaseReady, nil
+		return updated.Status.Phase == ogxiov1beta1.OGXServerPhaseReady, nil
 	})
-	requireNoErrorWithDebugging(t, TestEnv, err, "Failed to wait for distribution status update", distribution.Namespace, distribution.Name)
+	requireNoErrorWithDebugging(t, TestEnv, err, "Failed to wait for server status update", server.Namespace, server.Name)
 }
 
-func testDistributionStatus(t *testing.T, llsdistributionCR *v1alpha1.LlamaStackDistribution) {
+func testDistributionStatus(t *testing.T, server *ogxiov1beta1.OGXServer) {
 	t.Helper()
-	// Wait for status to be updated with distribution info
+
 	err := wait.PollUntilContextTimeout(TestEnv.Ctx, 1*time.Minute, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
-		updatedDistribution := &v1alpha1.LlamaStackDistribution{}
+		updated := &ogxiov1beta1.OGXServer{}
 		err := TestEnv.Client.Get(ctx, client.ObjectKey{
-			Namespace: llsdistributionCR.Namespace,
-			Name:      llsdistributionCR.Name,
-		}, updatedDistribution)
+			Namespace: server.Namespace,
+			Name:      server.Name,
+		}, updated)
 		if err != nil {
 			return false, err
 		}
 
-		return isDistributionStatusReady(updatedDistribution), nil
+		return isOGXServerStatusReady(updated), nil
 	})
 	if err != nil {
-		// Get the final state to print on error
-		finalDistribution := &v1alpha1.LlamaStackDistribution{}
+		finalServer := &ogxiov1beta1.OGXServer{}
 		TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
-			Namespace: llsdistributionCR.Namespace,
-			Name:      llsdistributionCR.Name,
-		}, finalDistribution)
-		requireNoErrorWithDebugging(t, TestEnv, err, "Failed to wait for distribution status update", llsdistributionCR.Namespace, llsdistributionCR.Name)
+			Namespace: server.Namespace,
+			Name:      server.Name,
+		}, finalServer)
+		requireNoErrorWithDebugging(t, TestEnv, err, "Failed to wait for distribution status update", server.Namespace, server.Name)
 	}
 
-	// Get final state and verify
-	updatedDistribution := &v1alpha1.LlamaStackDistribution{}
+	updated := &ogxiov1beta1.OGXServer{}
 	err = TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
-		Namespace: llsdistributionCR.Namespace,
-		Name:      llsdistributionCR.Name,
-	}, updatedDistribution)
+		Namespace: server.Namespace,
+		Name:      server.Name,
+	}, updated)
 	require.NoError(t, err)
 
-	// Verify distribution config (but allow it to be empty for some distributions)
-	if len(updatedDistribution.Status.DistributionConfig.AvailableDistributions) > 0 {
-		require.NotEmpty(t, updatedDistribution.Status.DistributionConfig.AvailableDistributions,
+	if len(updated.Status.DistributionConfig.AvailableDistributions) > 0 {
+		require.NotEmpty(t, updated.Status.DistributionConfig.AvailableDistributions,
 			"Available distributions should be populated")
 	}
 
-	if updatedDistribution.Status.DistributionConfig.ActiveDistribution != "" {
-		require.Equal(t, updatedDistribution.Spec.Server.Distribution.Name,
-			updatedDistribution.Status.DistributionConfig.ActiveDistribution,
+	if updated.Status.DistributionConfig.ActiveDistribution != "" {
+		require.Equal(t, updated.Spec.Distribution.Name,
+			updated.Status.DistributionConfig.ActiveDistribution,
 			"Active distribution should match the spec")
 	}
 
-	// Verify provider config and health (but allow it to be empty for some distributions)
-	if len(updatedDistribution.Status.DistributionConfig.Providers) > 0 {
-		// Verify that each provider has config and health info
-		validateProviders(t, updatedDistribution)
+	if len(updated.Status.DistributionConfig.Providers) > 0 {
+		validateProviders(t, updated)
 	} else {
 		t.Log("No providers found in distribution status - this might be expected for some distributions")
 	}
 
-	// Write the final distribution status to a file for CI to collect
-	yaml, err := yaml.Marshal(updatedDistribution)
+	yamlData, err := yaml.Marshal(updated)
 	if err != nil {
-		t.Fatalf("Failed to marshal distribution: %v", err)
+		t.Fatalf("Failed to marshal server: %v", err)
 	}
-	// Weak - do this better to write to a temp file and then move it to the right place at the
-	// repo's root so the CI agent can collect it
-	err = os.WriteFile("../../distribution.log", yaml, 0644)
+	err = os.WriteFile("../../distribution.log", yamlData, 0644)
 	require.NoError(t, err)
 }
 
-func testPVCConfiguration(t *testing.T, distribution *v1alpha1.LlamaStackDistribution) {
+func testPVCConfiguration(t *testing.T, server *ogxiov1beta1.OGXServer) {
 	t.Helper()
 
-	pvcName := distribution.Name + "-pvc"
+	pvcName := server.Name + "-pvc"
 	pvc := &corev1.PersistentVolumeClaim{}
 	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
-		Namespace: distribution.Namespace,
+		Namespace: server.Namespace,
 		Name:      pvcName,
 	}, pvc)
-	if distribution.Spec.Server.Storage == nil {
+
+	hasStorage := server.Spec.Workload != nil && server.Spec.Workload.Storage != nil
+	if !hasStorage {
 		require.Error(t, err, "PVC should not exist when storage is not configured")
 		require.True(t, k8serrors.IsNotFound(err), "Expected not found error for PVC when storage is not configured")
 	} else {
 		require.NoError(t, err, "PVC should be created when storage is configured")
-		// Check storage size
-		expectedSize := v1alpha1.DefaultStorageSize
-		if distribution.Spec.Server.Storage.Size != nil {
-			expectedSize = *distribution.Spec.Server.Storage.Size
+		expectedSize := ogxiov1beta1.DefaultStorageSize
+		if server.Spec.Workload.Storage.Size != nil {
+			expectedSize = *server.Spec.Workload.Storage.Size
 		}
 		actualSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
 		require.Equal(t, expectedSize.String(), actualSize.String(), "PVC storage size should match CR")
 	}
 }
 
-func testServiceAccountOverride(t *testing.T, distribution *v1alpha1.LlamaStackDistribution) {
+func testServiceAccountOverride(t *testing.T, server *ogxiov1beta1.OGXServer) {
 	t.Helper()
 
-	// Create a custom ServiceAccount
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "custom-sa",
-			Namespace: distribution.Namespace,
+			Namespace: server.Namespace,
 		},
 	}
 	require.NoError(t, TestEnv.Client.Create(TestEnv.Ctx, sa))
 	defer TestEnv.Client.Delete(TestEnv.Ctx, sa)
 
-	// Update the CR to use the custom ServiceAccount with retry logic
 	err := wait.PollUntilContextTimeout(TestEnv.Ctx, time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
-		// Get the latest version of the CR
-		latestDistribution := &v1alpha1.LlamaStackDistribution{}
+		latest := &ogxiov1beta1.OGXServer{}
 		if err := TestEnv.Client.Get(ctx, client.ObjectKey{
-			Namespace: distribution.Namespace,
-			Name:      distribution.Name,
-		}, latestDistribution); err != nil {
+			Namespace: server.Namespace,
+			Name:      server.Name,
+		}, latest); err != nil {
 			return false, err
 		}
 
-		// Update the ServiceAccount
-		latestDistribution.Spec.Server.PodOverrides = &v1alpha1.PodOverrides{
-			ServiceAccountName: "custom-sa",
+		if latest.Spec.Workload == nil {
+			latest.Spec.Workload = &ogxiov1beta1.WorkloadSpec{}
 		}
+		if latest.Spec.Workload.Overrides == nil {
+			latest.Spec.Workload.Overrides = &ogxiov1beta1.WorkloadOverrides{}
+		}
+		latest.Spec.Workload.Overrides.ServiceAccountName = "custom-sa"
 
-		// Try to update
-		if err := TestEnv.Client.Update(ctx, latestDistribution); err != nil {
+		if err := TestEnv.Client.Update(ctx, latest); err != nil {
 			if k8serrors.IsConflict(err) {
-				// If there's a conflict, return false to retry
 				return false, nil
 			}
 			return false, err
@@ -342,19 +322,16 @@ func testServiceAccountOverride(t *testing.T, distribution *v1alpha1.LlamaStackD
 	})
 	require.NoError(t, err, "Failed to update CR with ServiceAccount override")
 
-	// Wait for the deployment to be updated
 	time.Sleep(5 * time.Second)
 
-	// Get the deployment
 	deployment := &appsv1.Deployment{}
 	require.NoError(t, TestEnv.Client.Get(TestEnv.Ctx,
 		client.ObjectKey{
-			Name:      distribution.Name,
-			Namespace: distribution.Namespace,
+			Name:      server.Name,
+			Namespace: server.Namespace,
 		},
 		deployment))
 
-	// Verify the ServiceAccount is set correctly
 	assert.Equal(t, "custom-sa", deployment.Spec.Template.Spec.ServiceAccountName)
 }
 
@@ -367,45 +344,36 @@ func isDeploymentReady(u *unstructured.Unstructured) bool {
 	return found && err == nil && availableReplicas == replicas
 }
 
-// isDistributionStatusReady checks if the distribution status is ready.
-func isDistributionStatusReady(distribution *v1alpha1.LlamaStackDistribution) bool {
-	// Check that distribution config is populated - but this might not be required for all distributions
-	if len(distribution.Status.DistributionConfig.AvailableDistributions) == 0 {
-		// Allow this to be empty if the distribution is in ready phase
-		if distribution.Status.Phase != v1alpha1.LlamaStackDistributionPhaseReady {
+// isOGXServerStatusReady checks if the server status is ready.
+func isOGXServerStatusReady(server *ogxiov1beta1.OGXServer) bool {
+	if len(server.Status.DistributionConfig.AvailableDistributions) == 0 {
+		if server.Status.Phase != ogxiov1beta1.OGXServerPhaseReady {
 			return false
 		}
 	}
 
-	// Verify that the active distribution is set - but this might not be required for all distributions
-	if distribution.Status.DistributionConfig.ActiveDistribution == "" {
-		// Allow this to be empty if the distribution is in ready phase
-		if distribution.Status.Phase != v1alpha1.LlamaStackDistributionPhaseReady {
+	if server.Status.DistributionConfig.ActiveDistribution == "" {
+		if server.Status.Phase != ogxiov1beta1.OGXServerPhaseReady {
 			return false
 		}
 	}
 
-	// For now, we'll consider it ready if the phase is ready, even if providers are empty
-	// This is because the providers might be populated asynchronously
-	return distribution.Status.Phase == v1alpha1.LlamaStackDistributionPhaseReady
+	return server.Status.Phase == ogxiov1beta1.OGXServerPhaseReady
 }
 
-// validateProviders validates all providers in the distribution.
-func validateProviders(t *testing.T, distribution *v1alpha1.LlamaStackDistribution) {
+// validateProviders validates all providers in the server status.
+func validateProviders(t *testing.T, server *ogxiov1beta1.OGXServer) {
 	t.Helper()
 
-	for _, provider := range distribution.Status.DistributionConfig.Providers {
+	for _, provider := range server.Status.DistributionConfig.Providers {
 		require.NotEmpty(t, provider.API, "Provider should have API info")
 		require.NotEmpty(t, provider.ProviderID, "Provider should have ProviderID info")
 		require.NotEmpty(t, provider.ProviderType, "Provider should have ProviderType info")
 		require.NotNil(t, provider.Config, "Provider should have config info")
-		// If starter test it returns OK status
 		if provider.ProviderID == "starter" {
 			require.Equal(t, "OK", provider.Health.Status, "Provider should have OK health status")
 		}
-		// Check that status is one of the allowed values
 		require.Contains(t, []string{"OK", "Error", "Not Implemented"}, provider.Health.Status, "Provider health status should be one of: OK, Error, Not Implemented")
-		// There is no message for OK status
 		if provider.Health.Status != "OK" {
 			require.NotEmpty(t, provider.Health.Message, "Provider should have health message")
 		}
@@ -413,41 +381,35 @@ func validateProviders(t *testing.T, distribution *v1alpha1.LlamaStackDistributi
 	}
 }
 
-func testImageMappingOverrides(t *testing.T, distribution *v1alpha1.LlamaStackDistribution) {
+func testImageMappingOverrides(t *testing.T, server *ogxiov1beta1.OGXServer) {
 	t.Helper()
 
-	// Get the current deployment to save the original image
 	deployment := &appsv1.Deployment{}
 	require.NoError(t, TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
-		Namespace: distribution.Namespace,
-		Name:      distribution.Name,
+		Namespace: server.Namespace,
+		Name:      server.Name,
 	}, deployment))
 	originalImage := deployment.Spec.Template.Spec.Containers[0].Image
 
-	// Get the operator ConfigMap
 	operatorConfigMap := &corev1.ConfigMap{}
 	require.NoError(t, TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
 		Namespace: TestOpts.OperatorNS,
-		Name:      "llama-stack-operator-config",
+		Name:      "ogx-operator-config",
 	}, operatorConfigMap))
 
-	// Add image override for the distribution type
-	testOverrideImage := "quay.io/test/llama-stack:override-test"
+	testOverrideImage := "quay.io/test/ogx-server:override-test"
 	if operatorConfigMap.Data == nil {
 		operatorConfigMap.Data = make(map[string]string)
 	}
-	operatorConfigMap.Data["image-overrides"] = distribution.Spec.Server.Distribution.Name + ": " + testOverrideImage
+	operatorConfigMap.Data["image-overrides"] = server.Spec.Distribution.Name + ": " + testOverrideImage
 
-	// Update the ConfigMap
 	require.NoError(t, TestEnv.Client.Update(TestEnv.Ctx, operatorConfigMap),
 		"Failed to update operator ConfigMap with image overrides")
 
-	// Wait for the operator to reconcile and update the deployment
-	// The ConfigMap change should trigger reconciliation of all distributions
 	err := wait.PollUntilContextTimeout(TestEnv.Ctx, 10*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		getErr := TestEnv.Client.Get(ctx, client.ObjectKey{
-			Namespace: distribution.Namespace,
-			Name:      distribution.Name,
+			Namespace: server.Namespace,
+			Name:      server.Name,
 		}, deployment)
 		if getErr != nil {
 			return false, getErr
@@ -458,27 +420,24 @@ func testImageMappingOverrides(t *testing.T, distribution *v1alpha1.LlamaStackDi
 	})
 	requireNoErrorWithDebugging(t, TestEnv, err,
 		"Deployment should be updated with override image from ConfigMap",
-		distribution.Namespace, distribution.Name)
+		server.Namespace, server.Name)
 
-	// Verify the deployment is using the override image
 	require.NoError(t, TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
-		Namespace: distribution.Namespace,
-		Name:      distribution.Name,
+		Namespace: server.Namespace,
+		Name:      server.Name,
 	}, deployment))
 	assert.Equal(t, testOverrideImage, deployment.Spec.Template.Spec.Containers[0].Image,
 		"Deployment should use image from ConfigMap override")
 
-	// Test updating the override to a different image
-	updatedOverrideImage := "quay.io/test/llama-stack:override-test-v2"
-	operatorConfigMap.Data["image-overrides"] = distribution.Spec.Server.Distribution.Name + ": " + updatedOverrideImage
+	updatedOverrideImage := "quay.io/test/ogx-server:override-test-v2"
+	operatorConfigMap.Data["image-overrides"] = server.Spec.Distribution.Name + ": " + updatedOverrideImage
 	require.NoError(t, TestEnv.Client.Update(TestEnv.Ctx, operatorConfigMap),
 		"Failed to update operator ConfigMap with new image override")
 
-	// Wait for the deployment to update with the new override
 	err = wait.PollUntilContextTimeout(TestEnv.Ctx, 10*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		getErr := TestEnv.Client.Get(ctx, client.ObjectKey{
-			Namespace: distribution.Namespace,
-			Name:      distribution.Name,
+			Namespace: server.Namespace,
+			Name:      server.Name,
 		}, deployment)
 		if getErr != nil {
 			return false, getErr
@@ -489,19 +448,16 @@ func testImageMappingOverrides(t *testing.T, distribution *v1alpha1.LlamaStackDi
 	})
 	requireNoErrorWithDebugging(t, TestEnv, err,
 		"Deployment should be updated with new override image from ConfigMap",
-		distribution.Namespace, distribution.Name)
+		server.Namespace, server.Name)
 
-	// Clean up - remove the image-overrides entry from the ConfigMap
 	delete(operatorConfigMap.Data, "image-overrides")
-
 	require.NoError(t, TestEnv.Client.Update(TestEnv.Ctx, operatorConfigMap),
 		"Failed to restore operator ConfigMap")
 
-	// Wait for the deployment to revert to the original image
 	err = wait.PollUntilContextTimeout(TestEnv.Ctx, 10*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		getErr := TestEnv.Client.Get(ctx, client.ObjectKey{
-			Namespace: distribution.Namespace,
-			Name:      distribution.Name,
+			Namespace: server.Namespace,
+			Name:      server.Name,
 		}, deployment)
 		if getErr != nil {
 			return false, getErr
@@ -512,5 +468,5 @@ func testImageMappingOverrides(t *testing.T, distribution *v1alpha1.LlamaStackDi
 	})
 	requireNoErrorWithDebugging(t, TestEnv, err,
 		"Deployment should revert to original image after removing override",
-		distribution.Namespace, distribution.Name)
+		server.Namespace, server.Name)
 }

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -144,45 +144,55 @@ func testDirectDeploymentUpdates(t *testing.T, server *ogxiov1beta1.OGXServer) {
 func testCRDeploymentUpdate(t *testing.T, server *ogxiov1beta1.OGXServer) {
 	t.Helper()
 
-	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
-		Namespace: server.Namespace,
-		Name:      server.Name,
-	}, server)
-	require.NoError(t, err)
+	testEnvVar := corev1.EnvVar{Name: "E2E_TEST_MARKER", Value: "cr-update-test"}
 
-	if server.Spec.Workload != nil && server.Spec.Workload.Storage != nil {
-		t.Log("Skipping replica scaling test - PVC with ReadWriteOnce can only be attached to one pod at a time")
-		return
-	}
-
-	replicas := int32(2)
-	if server.Spec.Workload == nil {
-		server.Spec.Workload = &ogxiov1beta1.WorkloadSpec{}
-	}
-	server.Spec.Workload.Replicas = &replicas
-	err = TestEnv.Client.Update(TestEnv.Ctx, server)
-	require.NoError(t, err)
-
-	err = EnsureResourceReady(t, TestEnv, schema.GroupVersionKind{
-		Group:   "apps",
-		Version: "v1",
-		Kind:    "Deployment",
-	}, server.Name, server.Namespace, ResourceReadyTimeout, func(u *unstructured.Unstructured) bool {
-		availableReplicas, found, nestedErr := unstructured.NestedInt64(u.Object, "status", "availableReplicas")
-		if !found || nestedErr != nil {
-			return false
+	// Update the CR to add a new env var (retry on conflict)
+	err := wait.PollUntilContextTimeout(TestEnv.Ctx, time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		latest := &ogxiov1beta1.OGXServer{}
+		if getErr := TestEnv.Client.Get(ctx, client.ObjectKey{
+			Namespace: server.Namespace,
+			Name:      server.Name,
+		}, latest); getErr != nil {
+			return false, getErr
 		}
-		return availableReplicas == 2
+		if latest.Spec.Workload == nil {
+			latest.Spec.Workload = &ogxiov1beta1.WorkloadSpec{}
+		}
+		if latest.Spec.Workload.Overrides == nil {
+			latest.Spec.Workload.Overrides = &ogxiov1beta1.WorkloadOverrides{}
+		}
+		latest.Spec.Workload.Overrides.Env = append(latest.Spec.Workload.Overrides.Env, testEnvVar)
+		if updateErr := TestEnv.Client.Update(ctx, latest); updateErr != nil {
+			if k8serrors.IsConflict(updateErr) {
+				return false, nil
+			}
+			return false, updateErr
+		}
+		return true, nil
 	})
-	require.NoError(t, err, "Failed to wait for deployment to update replicas")
+	require.NoError(t, err, "Failed to update CR with test env var")
 
-	deployment := &appsv1.Deployment{}
-	err = TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
-		Namespace: server.Namespace,
-		Name:      server.Name,
-	}, deployment)
-	require.NoError(t, err)
-	require.Equal(t, int32(2), deployment.Status.AvailableReplicas, "Deployment should have 2 available replicas")
+	// Verify deployment pod template picks up the new env var
+	err = wait.PollUntilContextTimeout(TestEnv.Ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		deployment := &appsv1.Deployment{}
+		if getErr := TestEnv.Client.Get(ctx, client.ObjectKey{
+			Namespace: server.Namespace,
+			Name:      server.Name,
+		}, deployment); getErr != nil {
+			return false, getErr
+		}
+		for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+			if env.Name == testEnvVar.Name && env.Value == testEnvVar.Value {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	require.NoError(t, err, "Deployment should pick up env var from CR update")
+
+	// Wait for the rolled-out pod to be ready
+	err = WaitForPodsReady(t, TestEnv, server.Namespace, server.Name, ResourceReadyTimeout)
+	require.NoError(t, err, "Pod should be ready after CR update rollout")
 }
 
 func testHealthStatus(t *testing.T, server *ogxiov1beta1.OGXServer) {

--- a/tests/e2e/creation_test.go
+++ b/tests/e2e/creation_test.go
@@ -141,58 +141,58 @@ func testDirectDeploymentUpdates(t *testing.T, server *ogxiov1beta1.OGXServer) {
 	require.Equal(t, originalReplicas, *deployment.Spec.Replicas, "Deployment should be reverted to original state")
 }
 
-func testCRDeploymentUpdate(t *testing.T, server *ogxiov1beta1.OGXServer) {
-	t.Helper()
-
-	testEnvVar := corev1.EnvVar{Name: "E2E_TEST_MARKER", Value: "cr-update-test"}
-
-	// Update the CR to add a new env var (retry on conflict)
-	err := wait.PollUntilContextTimeout(TestEnv.Ctx, time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+func updateCRReplicas(server *ogxiov1beta1.OGXServer, replicas int32) error {
+	return wait.PollUntilContextTimeout(TestEnv.Ctx, time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		latest := &ogxiov1beta1.OGXServer{}
-		if getErr := TestEnv.Client.Get(ctx, client.ObjectKey{
+		if err := TestEnv.Client.Get(ctx, client.ObjectKey{
 			Namespace: server.Namespace,
 			Name:      server.Name,
-		}, latest); getErr != nil {
-			return false, getErr
+		}, latest); err != nil {
+			return false, err
 		}
 		if latest.Spec.Workload == nil {
 			latest.Spec.Workload = &ogxiov1beta1.WorkloadSpec{}
 		}
-		if latest.Spec.Workload.Overrides == nil {
-			latest.Spec.Workload.Overrides = &ogxiov1beta1.WorkloadOverrides{}
-		}
-		latest.Spec.Workload.Overrides.Env = append(latest.Spec.Workload.Overrides.Env, testEnvVar)
-		if updateErr := TestEnv.Client.Update(ctx, latest); updateErr != nil {
-			if k8serrors.IsConflict(updateErr) {
+		latest.Spec.Workload.Replicas = &replicas
+		if err := TestEnv.Client.Update(ctx, latest); err != nil {
+			if k8serrors.IsConflict(err) {
 				return false, nil
 			}
-			return false, updateErr
+			return false, err
 		}
 		return true, nil
 	})
-	require.NoError(t, err, "Failed to update CR with test env var")
+}
 
-	// Verify deployment pod template picks up the new env var
-	err = wait.PollUntilContextTimeout(TestEnv.Ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		deployment := &appsv1.Deployment{}
-		if getErr := TestEnv.Client.Get(ctx, client.ObjectKey{
-			Namespace: server.Namespace,
-			Name:      server.Name,
-		}, deployment); getErr != nil {
-			return false, getErr
+func testCRDeploymentUpdate(t *testing.T, server *ogxiov1beta1.OGXServer) {
+	t.Helper()
+
+	if server.Spec.Workload != nil && server.Spec.Workload.Autoscaling != nil && server.Spec.Workload.Autoscaling.MaxReplicas > 0 {
+		t.Skip("Skipping CR deployment update test when autoscaling is enabled")
+	}
+
+	// Scale to 0 via CR update
+	require.NoError(t, updateCRReplicas(server, 0), "Failed to update CR replicas to 0")
+
+	// Verify deployment scales to 0
+	err := EnsureResourceReady(t, TestEnv, schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
+	}, server.Name, server.Namespace, ResourceReadyTimeout, func(u *unstructured.Unstructured) bool {
+		specReplicas, found, nestedErr := unstructured.NestedInt64(u.Object, "spec", "replicas")
+		if !found || nestedErr != nil {
+			return false
 		}
-		for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
-			if env.Name == testEnvVar.Name && env.Value == testEnvVar.Value {
-				return true, nil
-			}
-		}
-		return false, nil
+		return specReplicas == 0
 	})
-	require.NoError(t, err, "Deployment should pick up env var from CR update")
+	require.NoError(t, err, "Deployment should scale to 0")
 
-	// Wait for the rolled-out pod to be ready
+	// Scale back to 1
+	require.NoError(t, updateCRReplicas(server, 1), "Failed to scale CR back to 1")
+
 	err = WaitForPodsReady(t, TestEnv, server.Namespace, server.Name, ResourceReadyTimeout)
-	require.NoError(t, err, "Pod should be ready after CR update rollout")
+	require.NoError(t, err, "Pod should be ready after scale-up")
 }
 
 func testHealthStatus(t *testing.T, server *ogxiov1beta1.OGXServer) {

--- a/tests/e2e/deletion_test.go
+++ b/tests/e2e/deletion_test.go
@@ -4,23 +4,21 @@ package e2e
 import (
 	"testing"
 
-	"github.com/ogx-ai/ogx-k8s-operator/api/v1alpha1"
+	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// runDeletionTests runs deletion tests for a specific distribution.
-func runDeletionTests(t *testing.T, instance *v1alpha1.LlamaStackDistribution) {
+// runDeletionTests runs deletion tests for a specific OGXServer.
+func runDeletionTests(t *testing.T, instance *ogxiov1beta1.OGXServer) {
 	t.Helper()
 
-	t.Run("should delete LlamaStackDistribution CR and cleanup resources", func(t *testing.T) {
-		// Delete the instance
+	t.Run("should delete OGXServer CR and cleanup resources", func(t *testing.T) {
 		err := TestEnv.Client.Delete(TestEnv.Ctx, instance)
 		require.NoError(t, err)
 
-		// Wait for deployment to be deleted
 		err = EnsureResourceDeleted(t, TestEnv, schema.GroupVersionKind{
 			Group:   "apps",
 			Version: "v1",
@@ -28,7 +26,6 @@ func runDeletionTests(t *testing.T, instance *v1alpha1.LlamaStackDistribution) {
 		}, instance.Name, instance.Namespace, ResourceReadyTimeout)
 		require.NoError(t, err, "Deployment should be deleted")
 
-		// Wait for service to be deleted
 		err = EnsureResourceDeleted(t, TestEnv, schema.GroupVersionKind{
 			Group:   "",
 			Version: "v1",
@@ -36,15 +33,13 @@ func runDeletionTests(t *testing.T, instance *v1alpha1.LlamaStackDistribution) {
 		}, instance.Name+"-service", instance.Namespace, ResourceReadyTimeout)
 		require.NoError(t, err, "Service should be deleted")
 
-		// Wait for CR to be deleted
 		err = EnsureResourceDeleted(t, TestEnv, schema.GroupVersionKind{
-			Group:   "llamastack.io",
-			Version: "v1alpha1",
-			Kind:    "LlamaStackDistribution",
+			Group:   "ogx.io",
+			Version: "v1beta1",
+			Kind:    "OGXServer",
 		}, instance.Name, instance.Namespace, ResourceReadyTimeout)
 		require.NoError(t, err, "CR should be deleted")
 
-		// Verify no orphaned resources
 		podList := &corev1.PodList{}
 		err = TestEnv.Client.List(TestEnv.Ctx, podList, client.InNamespace(instance.Namespace))
 		require.NoError(t, err)
@@ -52,7 +47,6 @@ func runDeletionTests(t *testing.T, instance *v1alpha1.LlamaStackDistribution) {
 			require.NotEqual(t, instance.Name, pod.Labels["app"], "Found orphaned pod")
 		}
 
-		// Verify no orphaned configmaps
 		configMapList := &corev1.ConfigMapList{}
 		err = TestEnv.Client.List(TestEnv.Ctx, configMapList, client.InNamespace(instance.Namespace))
 		require.NoError(t, err)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -4,7 +4,7 @@ package e2e
 import (
 	"testing"
 
-	"github.com/ogx-ai/ogx-k8s-operator/api/v1alpha1"
+	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
 )
 
 func TestE2E(t *testing.T) {
@@ -13,11 +13,9 @@ func TestE2E(t *testing.T) {
 	t.Run("validation", TestValidationSuite)
 
 	// Run combined creation and deletion tests for multiple distributions
-	// starter: newer image currently being actively updated
 	distributions := []string{"starter"}
 	for _, dist := range distributions {
 		t.Run("creation-deletion-"+dist, func(t *testing.T) {
-			// Set distribution type for this test run
 			t.Logf("Testing distribution: %s", dist)
 			runCreationDeletionSuiteForDistribution(t, dist)
 		})
@@ -37,18 +35,16 @@ func runCreationDeletionSuiteForDistribution(t *testing.T, distType string) {
 	}
 
 	var creationFailed bool
-	var createdDistribution *v1alpha1.LlamaStackDistribution
+	var createdServer *ogxiov1beta1.OGXServer
 
-	// Run all creation tests
 	t.Run("creation", func(t *testing.T) {
-		createdDistribution = runCreationTestsForDistribution(t, distType)
+		createdServer = runCreationTestsForDistribution(t, distType)
 		creationFailed = t.Failed()
 	})
 
-	// Run deletion tests only if creation passed
-	if !creationFailed && !TestOpts.SkipDeletion && createdDistribution != nil {
+	if !creationFailed && !TestOpts.SkipDeletion && createdServer != nil {
 		t.Run("deletion", func(t *testing.T) {
-			runDeletionTests(t, createdDistribution)
+			runDeletionTests(t, createdServer)
 		})
 	} else {
 		if TestOpts.SkipDeletion {

--- a/tests/e2e/rollout_test.go
+++ b/tests/e2e/rollout_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ogx-ai/ogx-k8s-operator/api/v1alpha1"
+	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,16 +19,14 @@ import (
 )
 
 const (
-	rolloutTestNS           = "llama-stack-rollout-test"
+	rolloutTestNS           = "ogx-rollout-test"
 	rolloutTestTimeout      = 5 * time.Minute
 	rolloutCRName           = "rollout-test"
 	ollamaInferenceModelEnv = "OLLAMA_INFERENCE_MODEL"
 )
 
-// TestRolloutWithStorage verifies that updating a LlamaStackDistribution
+// TestRolloutWithStorage verifies that updating an OGXServer
 // with persistent storage completes without RWO PVC multi-attach deadlock.
-// Requires a multi-node cluster. Cordons the initial pod's node to force
-// cross-node scheduling, guaranteeing the RWO conflict if strategy is wrong.
 func TestRolloutWithStorage(t *testing.T) {
 	if TestOpts.SkipCreation {
 		t.Skip("Skipping rollout test suite")
@@ -44,8 +42,8 @@ func TestRolloutWithStorage(t *testing.T) {
 		testCreateRolloutNamespace(t)
 	})
 
-	t.Run("should create distribution with storage", func(t *testing.T) {
-		testCreateDistributionWithStorage(t)
+	t.Run("should create OGXServer with storage", func(t *testing.T) {
+		testCreateServerWithStorage(t)
 	})
 
 	t.Run("should use Recreate strategy when storage is configured", func(t *testing.T) {
@@ -77,33 +75,33 @@ func testCreateRolloutNamespace(t *testing.T) {
 	}
 }
 
-func testCreateDistributionWithStorage(t *testing.T) {
+func testCreateServerWithStorage(t *testing.T) {
 	t.Helper()
 
-	cr := &v1alpha1.LlamaStackDistribution{
+	replicas := int32(1)
+	cr := &ogxiov1beta1.OGXServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rolloutCRName,
 			Namespace: rolloutTestNS,
 		},
-		Spec: v1alpha1.LlamaStackDistributionSpec{
-			Replicas: 1,
-			Server: v1alpha1.ServerSpec{
-				Distribution: v1alpha1.DistributionType{
-					Name: starterDistType,
-				},
-				ContainerSpec: v1alpha1.ContainerSpec{
-					Name: "llama-stack",
+		Spec: ogxiov1beta1.OGXServerSpec{
+			Distribution: ogxiov1beta1.DistributionSpec{
+				Name: starterDistType,
+			},
+			Workload: &ogxiov1beta1.WorkloadSpec{
+				Replicas: &replicas,
+				Storage:  &ogxiov1beta1.PVCStorageSpec{},
+				Overrides: &ogxiov1beta1.WorkloadOverrides{
 					Env: []corev1.EnvVar{
 						{Name: ollamaInferenceModelEnv, Value: "llama3.2:1b"},
 						{Name: "OLLAMA_URL", Value: "http://ollama-server-service.ollama-dist.svc.cluster.local:11434"},
 					},
 				},
-				Storage: &v1alpha1.StorageSpec{},
 			},
 		},
 	}
 
-	t.Log("Creating LlamaStackDistribution with persistent storage")
+	t.Log("Creating OGXServer with persistent storage")
 	require.NoError(t, TestEnv.Client.Create(TestEnv.Ctx, cr))
 
 	err := EnsureResourceReady(t, TestEnv, schema.GroupVersionKind{
@@ -144,10 +142,8 @@ func testRolloutAfterEnvVarUpdate(t *testing.T) {
 	cordonNodeForTest(t, initialNodeName)
 
 	t.Log("Updating OLLAMA_INFERENCE_MODEL to trigger rollout")
-	updateDistributionEnvVar(t, rolloutTestNS, rolloutCRName, ollamaInferenceModelEnv, "llama3.2:3b")
+	updateServerEnvVar(t, rolloutTestNS, rolloutCRName, ollamaInferenceModelEnv, "llama3.2:3b")
 
-	// Poll until the operator reconciles the env var into the Deployment,
-	// otherwise the old (still-ready) Deployment passes readiness immediately.
 	t.Log("Waiting for operator to update Deployment with new env var")
 	waitForDeploymentEnvVar(t, rolloutTestNS, rolloutCRName, ollamaInferenceModelEnv, "llama3.2:3b")
 
@@ -195,8 +191,6 @@ func testNoFailedAttachVolumeEvents(t *testing.T) {
 
 	for _, event := range eventList.Items {
 		if event.Reason == "FailedAttachVolume" {
-			// Transient during cross-node volume migration with Recreate strategy.
-			// A permanent deadlock (RollingUpdate) would have timed out above.
 			t.Logf("Transient FailedAttachVolume (expected): %s", event.Message)
 		}
 	}
@@ -205,13 +199,13 @@ func testNoFailedAttachVolumeEvents(t *testing.T) {
 func testRolloutCleanup(t *testing.T) {
 	t.Helper()
 
-	distribution := &v1alpha1.LlamaStackDistribution{
+	server := &ogxiov1beta1.OGXServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rolloutCRName,
 			Namespace: rolloutTestNS,
 		},
 	}
-	err := TestEnv.Client.Delete(TestEnv.Ctx, distribution)
+	err := TestEnv.Client.Delete(TestEnv.Ctx, server)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		require.NoError(t, err)
 	}
@@ -222,8 +216,7 @@ func testRolloutCleanup(t *testing.T) {
 	require.NoError(t, err, "Deployment should be deleted")
 }
 
-// cordonNodeForTest marks a node as unschedulable and registers a
-// t.Cleanup to uncordon it when the test finishes.
+// cordonNodeForTest marks a node as unschedulable and registers cleanup.
 func cordonNodeForTest(t *testing.T, nodeName string) {
 	t.Helper()
 
@@ -249,22 +242,28 @@ func cordonNodeForTest(t *testing.T, nodeName string) {
 	})
 }
 
-// updateDistributionEnvVar updates an env var on a LlamaStackDistribution,
-// retrying on conflict.
-func updateDistributionEnvVar(t *testing.T, namespace, name, envName, newValue string) {
+// updateServerEnvVar updates an env var on an OGXServer, retrying on conflict.
+func updateServerEnvVar(t *testing.T, namespace, name, envName, newValue string) {
 	t.Helper()
 
 	err := wait.PollUntilContextTimeout(TestEnv.Ctx, time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
-		latest := &v1alpha1.LlamaStackDistribution{}
+		latest := &ogxiov1beta1.OGXServer{}
 		if getErr := TestEnv.Client.Get(ctx, client.ObjectKey{
 			Namespace: namespace, Name: name,
 		}, latest); getErr != nil {
 			return false, getErr
 		}
 
-		for i, env := range latest.Spec.Server.ContainerSpec.Env {
+		if latest.Spec.Workload == nil {
+			latest.Spec.Workload = &ogxiov1beta1.WorkloadSpec{}
+		}
+		if latest.Spec.Workload.Overrides == nil {
+			latest.Spec.Workload.Overrides = &ogxiov1beta1.WorkloadOverrides{}
+		}
+
+		for i, env := range latest.Spec.Workload.Overrides.Env {
 			if env.Name == envName {
-				latest.Spec.Server.ContainerSpec.Env[i].Value = newValue
+				latest.Spec.Workload.Overrides.Env[i].Value = newValue
 				break
 			}
 		}
@@ -280,8 +279,7 @@ func updateDistributionEnvVar(t *testing.T, namespace, name, envName, newValue s
 	require.NoError(t, err, "Failed to update CR env var "+envName)
 }
 
-// waitForDeploymentEnvVar polls until the Deployment's container spec
-// reflects the expected env var value.
+// waitForDeploymentEnvVar polls until the Deployment reflects the expected env var value.
 func waitForDeploymentEnvVar(t *testing.T, namespace, name, envName, expectedValue string) {
 	t.Helper()
 

--- a/tests/e2e/test_options.go
+++ b/tests/e2e/test_options.go
@@ -22,7 +22,7 @@ func NewTestOptions() *TestOptions {
 		SkipValidation: false,
 		SkipCreation:   false,
 		SkipDeletion:   false,
-		OperatorNS:     "llama-stack-k8s-operator-system",
+		OperatorNS:     "ogx-k8s-operator-system",
 	}
 }
 

--- a/tests/e2e/test_utils.go
+++ b/tests/e2e/test_utils.go
@@ -289,6 +289,13 @@ func GetSampleCRForDistribution(t *testing.T, distType string) *ogxiov1beta1.OGX
 		t.Fatalf("Unknown distribution type: %s", distType)
 	}
 
+	if server.Spec.Workload != nil {
+		server.Spec.Workload.Autoscaling = nil
+		server.Spec.Workload.Storage = nil
+		server.Spec.Workload.PodDisruptionBudget = nil
+		server.Spec.Workload.TopologySpreadConstraints = nil
+	}
+
 	return server
 }
 

--- a/tests/e2e/test_utils.go
+++ b/tests/e2e/test_utils.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ogx-ai/ogx-k8s-operator/api/v1alpha1"
+	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -49,13 +49,11 @@ type TestEnvironment struct {
 
 // SetupTestEnv sets up the test environment.
 func SetupTestEnv() (*TestEnvironment, error) {
-	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	// Create a new client
 	cl, err := client.New(cfg, client.Options{Scheme: Scheme})
 	if err != nil {
 		return nil, err
@@ -154,7 +152,6 @@ func WaitForPodsReady(t *testing.T, testenv *TestEnvironment, namespace, deploym
 	defer cancel()
 
 	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-		// Get pods for the deployment
 		podList, err := GetPodsForDeployment(testenv, ctx, namespace, deploymentName)
 		if err != nil {
 			t.Logf("Error listing pods: %v", err)
@@ -166,7 +163,6 @@ func WaitForPodsReady(t *testing.T, testenv *TestEnvironment, namespace, deploym
 			return false, nil
 		}
 
-		// Check each pod's status
 		for _, pod := range podList.Items {
 			ready, err := checkPodStatus(t, &pod)
 			if err != nil {
@@ -187,19 +183,16 @@ func checkPodStatus(t *testing.T, pod *corev1.Pod) (bool, error) {
 	t.Helper()
 	t.Logf("Pod %s status: Phase=%s, Ready=%v", pod.Name, pod.Status.Phase, isPodReady(pod))
 
-	// Check if pod is running
 	if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodSucceeded {
 		t.Logf("Pod %s not running yet (phase: %s)", pod.Name, pod.Status.Phase)
 		return false, nil
 	}
 
-	// Check if pod is ready
 	if !isPodReady(pod) {
 		t.Logf("Pod %s not ready yet", pod.Name)
 		return false, nil
 	}
 
-	// Check container statuses for errors
 	return checkContainerStatuses(t, pod)
 }
 
@@ -213,7 +206,6 @@ func checkContainerStatuses(t *testing.T, pod *corev1.Pod) (bool, error) {
 				containerStatus.State.Waiting.Reason,
 				containerStatus.State.Waiting.Message)
 
-			// Fail fast on image pull errors or crash loops
 			if containerStatus.State.Waiting.Reason == "ImagePullBackOff" ||
 				containerStatus.State.Waiting.Reason == "ErrImagePull" ||
 				containerStatus.State.Waiting.Reason == "CrashLoopBackOff" {
@@ -266,7 +258,7 @@ func registerSchemes() {
 	schemes := []func(*runtime.Scheme) error{
 		clientgoscheme.AddToScheme,
 		apiextv1.AddToScheme,
-		v1alpha1.AddToScheme,
+		ogxiov1beta1.AddToScheme,
 	}
 
 	for _, schemeFn := range schemes {
@@ -274,53 +266,48 @@ func registerSchemes() {
 	}
 }
 
-// GetSampleCRForDistribution returns a LlamaStackDistribution configured for the specified distribution type.
-func GetSampleCRForDistribution(t *testing.T, distType string) *v1alpha1.LlamaStackDistribution {
+// GetSampleCRForDistribution returns an OGXServer configured for the specified distribution type.
+func GetSampleCRForDistribution(t *testing.T, distType string) *ogxiov1beta1.OGXServer {
 	t.Helper()
-	// Get the absolute path of the project root
 	projectRoot, err := filepath.Abs("../..")
 	require.NoError(t, err)
 
-	// Construct the path to the sample file
-	samplePath := filepath.Join(projectRoot, "config", "samples", "_v1alpha1_llamastackdistribution.yaml")
+	samplePath := filepath.Join(projectRoot, "config", "samples", "_v1beta1_ogxserver.yaml")
 
-	// Read the sample file
 	yamlFile, err := os.ReadFile(samplePath)
 	require.NoError(t, err)
 
-	// Create and unmarshal the distribution
-	distribution := &v1alpha1.LlamaStackDistribution{}
-	err = yaml.Unmarshal(yamlFile, distribution)
+	server := &ogxiov1beta1.OGXServer{}
+	err = yaml.Unmarshal(yamlFile, server)
 	require.NoError(t, err)
 
-	// Modify the distribution based on the type
 	switch distType {
 	case starterDistType:
-		distribution.Spec.Server.Distribution.Name = starterDistType
-		distribution.ObjectMeta.Name = "llamastackdistribution-" + starterDistType + "-sample"
+		server.Spec.Distribution.Name = starterDistType
+		server.ObjectMeta.Name = "ogxserver-" + starterDistType + "-sample"
 	default:
 		t.Fatalf("Unknown distribution type: %s", distType)
 	}
 
-	return distribution
+	return server
 }
 
-// checkLlamaStackDistributionStatus helps identify if the custom resource reached the expected state during test execution.
-func checkLlamaStackDistributionStatus(t *testing.T, testenv *TestEnvironment, namespace, name string) {
+// checkOGXServerStatus helps identify if the custom resource reached the expected state during test execution.
+func checkOGXServerStatus(t *testing.T, testenv *TestEnvironment, namespace, name string) {
 	t.Helper()
 
-	llsDistro := &v1alpha1.LlamaStackDistribution{}
-	err := testenv.Client.Get(testenv.Ctx, client.ObjectKey{Namespace: namespace, Name: name}, llsDistro)
+	ogxServer := &ogxiov1beta1.OGXServer{}
+	err := testenv.Client.Get(testenv.Ctx, client.ObjectKey{Namespace: namespace, Name: name}, ogxServer)
 	if err != nil {
-		t.Logf("⚠️  Error getting LlamaStackDistribution: %v", err)
+		t.Logf("Error getting OGXServer: %v", err)
 		return
 	}
 
-	t.Logf("LlamaStackDistribution status:")
-	t.Logf("  Phase: %s", llsDistro.Status.Phase)
-	t.Logf("  Generation: %d", llsDistro.Generation)
-	t.Logf("  ResourceVersion: %s", llsDistro.ResourceVersion)
-	t.Logf("  Conditions: %+v", llsDistro.Status.Conditions)
+	t.Logf("OGXServer status:")
+	t.Logf("  Phase: %s", ogxServer.Status.Phase)
+	t.Logf("  Generation: %d", ogxServer.Generation)
+	t.Logf("  ResourceVersion: %s", ogxServer.ResourceVersion)
+	t.Logf("  Conditions: %+v", ogxServer.Status.Conditions)
 }
 
 // checkNamespaceEvents reveals what Kubernetes operations occurred and why they may have failed.
@@ -330,21 +317,21 @@ func checkNamespaceEvents(t *testing.T, testenv *TestEnvironment, namespace stri
 	eventList := &corev1.EventList{}
 	err := testenv.Client.List(testenv.Ctx, eventList, client.InNamespace(namespace))
 	if err != nil {
-		t.Logf("⚠️  Error getting events: %v", err)
+		t.Logf("Error getting events: %v", err)
 		return
 	}
 
 	if len(eventList.Items) == 0 {
-		t.Log("📝 No events found in namespace")
+		t.Log("No events found in namespace")
 		return
 	}
 
 	maxEvents := 25
 	if len(eventList.Items) > maxEvents {
-		t.Logf("📝 Showing first %d events (of %d total):", maxEvents, len(eventList.Items))
+		t.Logf("Showing first %d events (of %d total):", maxEvents, len(eventList.Items))
 		eventList.Items = eventList.Items[:maxEvents]
 	} else {
-		t.Logf("📝 Found %d events in namespace %s:", len(eventList.Items), namespace)
+		t.Logf("Found %d events in namespace %s:", len(eventList.Items), namespace)
 	}
 
 	for _, event := range eventList.Items {
@@ -356,28 +343,17 @@ func checkNamespaceEvents(t *testing.T, testenv *TestEnvironment, namespace stri
 	}
 }
 
-// requireNoErrorWithDebugging provides comprehensive debugging context when tests fail to help identify root causes quickly.
+// requireNoErrorWithDebugging provides comprehensive debugging context when tests fail.
 func requireNoErrorWithDebugging(t *testing.T, testenv *TestEnvironment, err error, msg string, namespace, crName string) {
 	t.Helper()
 	if err != nil {
-		t.Logf("💥 ERROR OCCURRED: %s - %v", msg, err)
+		t.Logf("ERROR OCCURRED: %s - %v", msg, err)
 
-		// Check custom resource status first to see if the operator processed the request correctly
-		checkLlamaStackDistributionStatus(t, testenv, namespace, crName)
-
-		// Check events to understand what Kubernetes operations were attempted and why they failed
+		checkOGXServerStatus(t, testenv, namespace, crName)
 		checkNamespaceEvents(t, testenv, namespace)
-
-		// Check pod details to identify container startup issues or crash loops
 		logPodDetails(t, testenv, namespace)
-
-		// Check service endpoints to see if pods are being discovered by services
 		logServiceEndpoints(t, testenv, namespace, crName+"-service")
-
-		// Check service configuration to identify selector mismatches
 		logServiceSpec(t, testenv, namespace, crName+"-service")
-
-		// Check deployment spec to identify configuration problems preventing pod startup
 		logDeploymentSpec(t, testenv, namespace, crName)
 
 		require.NoError(t, err, msg)
@@ -395,16 +371,14 @@ func logPodDetails(t *testing.T, testenv *TestEnvironment, namespace string) {
 		return
 	}
 
-	t.Logf("📦 Found %d pods in namespace %s:", len(podList.Items), namespace)
+	t.Logf("Found %d pods in namespace %s:", len(podList.Items), namespace)
 	for _, pod := range podList.Items {
 		t.Logf("Pod: %s, Phase: %s", pod.Name, pod.Status.Phase)
 
 		for _, cs := range pod.Status.ContainerStatuses {
-			// RestartCount indicates crash loops or configuration issues
 			t.Logf("  Container %s: Ready=%v, RestartCount=%d",
 				cs.Name, cs.Ready, cs.RestartCount)
 
-			// Container states reveal why pods aren't starting or are crashing
 			if cs.State.Waiting != nil {
 				t.Logf("    Waiting: %s - %s",
 					cs.State.Waiting.Reason, cs.State.Waiting.Message)
@@ -415,7 +389,6 @@ func logPodDetails(t *testing.T, testenv *TestEnvironment, namespace string) {
 			}
 		}
 
-		// Pod logs would show startup errors but require different client access
 		t.Logf("  (Pod logs require direct kubectl access)")
 	}
 }
@@ -424,7 +397,6 @@ func logPodDetails(t *testing.T, testenv *TestEnvironment, namespace string) {
 func logServiceEndpoints(t *testing.T, testenv *TestEnvironment, namespace, serviceName string) {
 	t.Helper()
 
-	// List all EndpointSlices for the service
 	endpointSliceList := &discoveryv1.EndpointSliceList{}
 	err := testenv.Client.List(testenv.Ctx, endpointSliceList,
 		client.InNamespace(namespace),
@@ -436,11 +408,11 @@ func logServiceEndpoints(t *testing.T, testenv *TestEnvironment, namespace, serv
 	}
 
 	if len(endpointSliceList.Items) == 0 {
-		t.Logf("🔗 Service %s has no endpoint slices", serviceName)
+		t.Logf("Service %s has no endpoint slices", serviceName)
 		return
 	}
 
-	t.Logf("🔗 Service %s endpoints:", serviceName)
+	t.Logf("Service %s endpoints:", serviceName)
 	for i, slice := range endpointSliceList.Items {
 		t.Logf("  EndpointSlice %d (%s):", i, slice.Name)
 		logEndpointSliceDetails(t, &slice)
@@ -511,9 +483,8 @@ func logDeploymentSpec(t *testing.T, testenv *TestEnvironment, namespace, name s
 		return
 	}
 
-	t.Logf("🚀 Deployment %s spec:", name)
+	t.Logf("Deployment %s spec:", name)
 	t.Logf("  Replicas: %d", *deployment.Spec.Replicas)
-	// Selector must match pod labels or pods won't be managed by deployment
 	t.Logf("  Selector: %+v", deployment.Spec.Selector.MatchLabels)
 	t.Logf("  Template labels: %+v", deployment.Spec.Template.Labels)
 
@@ -524,12 +495,10 @@ func logDeploymentSpec(t *testing.T, testenv *TestEnvironment, namespace, name s
 		for _, port := range container.Ports {
 			t.Logf("      - %d", port.ContainerPort)
 		}
-		// Environment variables can cause startup failures if misconfigured
 		t.Logf("    Env vars:")
 		for _, env := range container.Env {
 			t.Logf("      %s=%s", env.Name, env.Value)
 		}
-		// Readiness probe configuration affects when pods become service endpoints
 		if container.ReadinessProbe != nil {
 			t.Logf("    Readiness probe: %+v", container.ReadinessProbe)
 		}
@@ -551,9 +520,8 @@ func logServiceSpec(t *testing.T, testenv *TestEnvironment, namespace, serviceNa
 		return
 	}
 
-	t.Logf("🔧 Service %s spec:", serviceName)
+	t.Logf("Service %s spec:", serviceName)
 	t.Logf("  Type: %s", service.Spec.Type)
-	// Selector must match pod labels or service won't route traffic to pods
 	t.Logf("  Selector: %+v", service.Spec.Selector)
 	t.Logf("  Ports:")
 	for _, port := range service.Spec.Ports {

--- a/tests/e2e/tls_test.go
+++ b/tests/e2e/tls_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ogx-ai/ogx-k8s-operator/api/v1alpha1"
+	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
 	"github.com/ogx-ai/ogx-k8s-operator/controllers"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -28,7 +28,7 @@ import (
 
 const (
 	tlsTestTimeout = 5 * time.Minute
-	llsTestNS      = "llama-stack-test"
+	ogxTestNS      = "ogx-test"
 )
 
 func TestTLSSuite(t *testing.T) {
@@ -36,7 +36,6 @@ func TestTLSSuite(t *testing.T) {
 		t.Skip("Skipping TLS test suite")
 	}
 
-	// Generate certificates before running any tests
 	t.Run("should generate certificates", func(t *testing.T) {
 		generateCertificates(t)
 	})
@@ -45,8 +44,8 @@ func TestTLSSuite(t *testing.T) {
 		testCreateNamespace(t)
 	})
 
-	t.Run("should create LlamaStackDistribution with CA bundle", func(t *testing.T) {
-		testLlamaStackWithCABundle(t)
+	t.Run("should create OGXServer with CA bundle", func(t *testing.T) {
+		testOGXServerWithCABundle(t)
 	})
 
 	t.Run("should cleanup TLS resources", func(t *testing.T) {
@@ -57,10 +56,9 @@ func TestTLSSuite(t *testing.T) {
 func testCreateNamespace(t *testing.T) {
 	t.Helper()
 
-	// Create test namespace
 	testNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: llsTestNS,
+			Name: ogxTestNS,
 		},
 	}
 	err := TestEnv.Client.Create(TestEnv.Ctx, testNs)
@@ -68,92 +66,74 @@ func testCreateNamespace(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Create CA bundle configmap in test namespace
-	err = createCABundleConfigMap(t, llsTestNS)
+	err = createCABundleConfigMap(t, ogxTestNS)
 	require.NoError(t, err)
 
-	// Verify the CA bundle ConfigMap was created correctly
-	err = verifyCABundleConfigMap(t, llsTestNS)
+	err = verifyCABundleConfigMap(t, ogxTestNS)
 	require.NoError(t, err)
 }
 
-func testLlamaStackWithCABundle(t *testing.T) {
+func testOGXServerWithCABundle(t *testing.T) {
 	t.Helper()
 
-	// Deploy LlamaStackDistribution with CA bundle
-	err := deployLlamaStackWithCABundle(t)
+	err := deployOGXServerWithCABundle(t)
 	require.NoError(t, err)
 
-	// The YAML file creates a placeholder ConfigMap, so we need to update it with the actual CA bundle
-	err = updateCABundleConfigMap(t, llsTestNS)
+	err = updateCABundleConfigMap(t, ogxTestNS)
 	require.NoError(t, err)
 
-	// Verify the CA bundle ConfigMap has the correct content after update
-	err = verifyCABundleConfigMap(t, llsTestNS)
+	err = verifyCABundleConfigMap(t, ogxTestNS)
 	require.NoError(t, err)
 
-	// Verify the LlamaStack distribution is configured with TLS
-	err = verifyLlamaStackTLSConfig(t, llsTestNS, "llamastack-with-config")
+	err = verifyOGXServerCABundleConfig(t, ogxTestNS, "ogxserver-with-config")
 	require.NoError(t, err)
 
-	// Wait for the operator to process the LlamaStackDistribution and create the deployment
-	err = waitForDeploymentCreation(t, llsTestNS, "llamastack-with-config", 3*time.Minute)
-	require.NoError(t, err, "LlamaStack deployment should be created by operator")
+	err = waitForDeploymentCreation(t, ogxTestNS, "ogxserver-with-config", 3*time.Minute)
+	require.NoError(t, err, "OGXServer deployment should be created by operator")
 
-	// Wait for pods to be running and ready
-	err = WaitForPodsReady(t, TestEnv, llsTestNS, "llamastack-with-config", 5*time.Minute)
-	require.NoError(t, err, "LlamaStack pods should be running and ready")
+	err = WaitForPodsReady(t, TestEnv, ogxTestNS, "ogxserver-with-config", 5*time.Minute)
+	require.NoError(t, err, "OGXServer pods should be running and ready")
 
-	// Verify certificate volumes are mounted correctly
-	err = verifyCertificateMounts(t, llsTestNS, "llamastack-with-config")
+	err = verifyCertificateMounts(t, ogxTestNS, "ogxserver-with-config")
 	require.NoError(t, err, "Certificate volumes should be mounted correctly")
 
-	// Verify environment variables are set correctly
-	err = verifyEnvironmentVariables(t, llsTestNS, "llamastack-with-config")
+	err = verifyEnvironmentVariables(t, ogxTestNS, "ogxserver-with-config")
 	require.NoError(t, err, "Environment variables should be set correctly")
 }
 
 func testTLSCleanup(t *testing.T) {
 	t.Helper()
 
-	// Delete LlamaStackDistribution
-	distribution := &v1alpha1.LlamaStackDistribution{
+	server := &ogxiov1beta1.OGXServer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "llamastack-with-config",
-			Namespace: llsTestNS,
+			Name:      "ogxserver-with-config",
+			Namespace: ogxTestNS,
 		},
 	}
-	err := TestEnv.Client.Delete(TestEnv.Ctx, distribution)
+	err := TestEnv.Client.Delete(TestEnv.Ctx, server)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		require.NoError(t, err)
 	}
 
-	// Wait for LlamaStack resources to be cleaned up
 	err = EnsureResourceDeleted(t, TestEnv, schema.GroupVersionKind{
 		Group:   "apps",
 		Version: "v1",
 		Kind:    "Deployment",
-	}, "llamastack-with-config", llsTestNS, ResourceReadyTimeout)
-	require.NoError(t, err, "LlamaStack deployment should be deleted")
+	}, "ogxserver-with-config", ogxTestNS, ResourceReadyTimeout)
+	require.NoError(t, err, "OGXServer deployment should be deleted")
 }
-
-// Helper functions
 
 func generateCertificates(t *testing.T) {
 	t.Helper()
 
-	// Get the project root path
 	projectRoot, err := filepath.Abs("../..")
 	require.NoError(t, err, "Failed to get project root")
 
-	// Run the certificate generation script
 	scriptPath := filepath.Join(projectRoot, "config", "samples", "generate_certificates.sh")
 	t.Logf("Running certificate generation script: %s", scriptPath)
 
-	// Change to the project root directory to run the script
 	t.Chdir(projectRoot)
 
-	// Execute the script
 	cmd := exec.CommandContext(t.Context(), "bash", scriptPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -167,13 +147,11 @@ func generateCertificates(t *testing.T) {
 func createCABundleConfigMap(t *testing.T, targetNS string) error {
 	t.Helper()
 
-	// Get the project root path
 	projectRoot, err := filepath.Abs("../..")
 	if err != nil {
 		return fmt.Errorf("failed to get project root: %w", err)
 	}
 
-	// Read CA bundle
 	caBundle, err := os.ReadFile(filepath.Join(projectRoot, "config", "samples", "vllm-ca-certs", controllers.DefaultCABundleKey))
 	if err != nil {
 		return fmt.Errorf("failed to read CA bundle: %w", err)
@@ -189,11 +167,9 @@ func createCABundleConfigMap(t *testing.T, targetNS string) error {
 		},
 	}
 
-	// Try to create, if it exists, update it
 	err = TestEnv.Client.Create(TestEnv.Ctx, caBundleConfigMap)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			// ConfigMap exists, update it
 			existingConfigMap := &corev1.ConfigMap{}
 			err = TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
 				Namespace: targetNS,
@@ -221,7 +197,6 @@ func createCABundleConfigMap(t *testing.T, targetNS string) error {
 func verifyCABundleConfigMap(t *testing.T, targetNS string) error {
 	t.Helper()
 
-	// Get the ConfigMap
 	configMap := &corev1.ConfigMap{}
 	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
 		Namespace: targetNS,
@@ -231,7 +206,6 @@ func verifyCABundleConfigMap(t *testing.T, targetNS string) error {
 		return fmt.Errorf("failed to get CA bundle ConfigMap: %w", err)
 	}
 
-	// Verify the CA bundle content exists
 	caBundle, exists := configMap.Data[controllers.DefaultCABundleKey]
 	if !exists {
 		return fmt.Errorf("failed to find %s CA bundle key in ConfigMap", controllers.DefaultCABundleKey)
@@ -241,12 +215,10 @@ func verifyCABundleConfigMap(t *testing.T, targetNS string) error {
 		return fmt.Errorf("failed to find any keys in CA bundle ConfigMap %s", controllers.DefaultCABundleKey)
 	}
 
-	// Check if CA bundle appears to be a placeholder
 	if len(caBundle) < 100 || !strings.Contains(caBundle, "BEGIN CERTIFICATE") {
 		t.Logf("WARNING: CA bundle appears to be a placeholder or invalid")
 		t.Logf("CA bundle content: %s", caBundle)
 
-		// Try to update the ConfigMap with the actual CA bundle from the file
 		err := updateCABundleConfigMap(t, targetNS)
 		if err != nil {
 			t.Logf("Failed to update CA bundle ConfigMap: %v", err)
@@ -256,26 +228,20 @@ func verifyCABundleConfigMap(t *testing.T, targetNS string) error {
 	return nil
 }
 
-func verifyLlamaStackTLSConfig(t *testing.T, namespace, name string) error {
+func verifyOGXServerCABundleConfig(t *testing.T, namespace, name string) error {
 	t.Helper()
 
-	// Get the LlamaStack distribution
-	distribution := &v1alpha1.LlamaStackDistribution{}
+	server := &ogxiov1beta1.OGXServer{}
 	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
 		Namespace: namespace,
 		Name:      name,
-	}, distribution)
+	}, server)
 	if err != nil {
-		return fmt.Errorf("failed to get LlamaStack distribution: %w", err)
+		return fmt.Errorf("failed to get OGXServer: %w", err)
 	}
 
-	// Verify TLS configuration is present
-	if distribution.Spec.Server.TLSConfig == nil {
-		return errors.New("LlamaStack distribution does not have TLS config")
-	}
-
-	if distribution.Spec.Server.TLSConfig.CABundle == nil {
-		return errors.New("LlamaStack distribution TLS config does not have CA bundle")
+	if server.Spec.TLS == nil || server.Spec.TLS.Trust == nil || len(server.Spec.TLS.Trust.CACertificates) == 0 {
+		return errors.New("OGXServer does not have CA bundle config (spec.tls.trust.caCertificates)")
 	}
 
 	return nil
@@ -284,19 +250,16 @@ func verifyLlamaStackTLSConfig(t *testing.T, namespace, name string) error {
 func updateCABundleConfigMap(t *testing.T, targetNS string) error {
 	t.Helper()
 
-	// Get the project root path
 	projectRoot, err := filepath.Abs("../..")
 	if err != nil {
 		return fmt.Errorf("failed to get project root: %w", err)
 	}
 
-	// Read the actual CA bundle from the file
 	actualCABundle, err := os.ReadFile(filepath.Join(projectRoot, "config", "samples", "vllm-ca-certs", controllers.DefaultCABundleKey))
 	if err != nil {
 		return fmt.Errorf("failed to read CA bundle file: %w", err)
 	}
 
-	// Get the existing ConfigMap
 	configMap := &corev1.ConfigMap{}
 	err = TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
 		Namespace: targetNS,
@@ -306,7 +269,6 @@ func updateCABundleConfigMap(t *testing.T, targetNS string) error {
 		return fmt.Errorf("failed to get ConfigMap: %w", err)
 	}
 
-	// Update the ConfigMap with the actual CA bundle
 	configMap.Data[controllers.DefaultCABundleKey] = string(actualCABundle)
 
 	err = TestEnv.Client.Update(TestEnv.Ctx, configMap)
@@ -317,36 +279,33 @@ func updateCABundleConfigMap(t *testing.T, targetNS string) error {
 	return nil
 }
 
-func deployLlamaStackWithCABundle(t *testing.T) error {
+func deployOGXServerWithCABundle(t *testing.T) error {
 	t.Helper()
 
-	// Read LlamaStack TLS test configuration
 	projectRoot, err := filepath.Abs("../..")
 	if err != nil {
 		return fmt.Errorf("failed to get project root: %w", err)
 	}
 
-	llamaStackConfigPath := filepath.Join(projectRoot, "config", "samples", "example-with-ca-bundle.yaml")
-	llamaStackConfigData, err := os.ReadFile(llamaStackConfigPath)
+	configPath := filepath.Join(projectRoot, "config", "samples", "example-with-ca-bundle.yaml")
+	configData, err := os.ReadFile(configPath)
 	if err != nil {
-		return fmt.Errorf("failed to read LlamaStack config: %w", err)
+		return fmt.Errorf("failed to read OGXServer config: %w", err)
 	}
 
-	// Apply LlamaStack configuration
-	objects, err := parseKubernetesYAML(llamaStackConfigData)
+	objects, err := parseKubernetesYAML(configData)
 	if err != nil {
-		return fmt.Errorf("failed to parse LlamaStack config: %w", err)
+		return fmt.Errorf("failed to parse OGXServer config: %w", err)
 	}
 
 	for _, obj := range objects {
-		// Set the namespace for namespaced resources
 		if obj.GetNamespace() == "" {
-			obj.SetNamespace(llsTestNS)
+			obj.SetNamespace(ogxTestNS)
 		}
 
 		err = TestEnv.Client.Create(TestEnv.Ctx, obj)
 		if err != nil && !k8serrors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create LlamaStack resource: %w", err)
+			return fmt.Errorf("failed to create OGXServer resource: %w", err)
 		}
 	}
 
@@ -356,7 +315,6 @@ func deployLlamaStackWithCABundle(t *testing.T) error {
 func verifyCertificateMounts(t *testing.T, namespace, name string) error {
 	t.Helper()
 
-	// Get the deployment
 	deployment := &appsv1.Deployment{}
 	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
 		Namespace: namespace,
@@ -366,12 +324,10 @@ func verifyCertificateMounts(t *testing.T, namespace, name string) error {
 		return fmt.Errorf("failed to get deployment: %w", err)
 	}
 
-	// Check if CA bundle volume is defined
 	if !hasCABundleVolume(deployment.Spec.Template.Spec.Volumes) {
 		return errors.New("CA bundle volume not found in deployment")
 	}
 
-	// Check if CA bundle is mounted in any container
 	if !hasCABundleMount(deployment.Spec.Template.Spec.Containers) {
 		return errors.New("CA bundle mount not found in any container")
 	}
@@ -381,8 +337,6 @@ func verifyCertificateMounts(t *testing.T, namespace, name string) error {
 
 func hasCABundleVolume(volumes []corev1.Volume) bool {
 	for _, volume := range volumes {
-		// Check for the managed CA bundle ConfigMap (named {instance-name}-ca-bundle)
-		// or the source CA bundle ConfigMap
 		if volume.ConfigMap != nil &&
 			(strings.HasSuffix(volume.ConfigMap.Name, "-ca-bundle") ||
 				volume.ConfigMap.Name == "custom-ca-bundle") {
@@ -415,7 +369,6 @@ func hasCABundleMountInContainer(mounts []corev1.VolumeMount) bool {
 func verifyEnvironmentVariables(t *testing.T, namespace, name string) error {
 	t.Helper()
 
-	// Get the deployment
 	deployment := &appsv1.Deployment{}
 	err := TestEnv.Client.Get(TestEnv.Ctx, client.ObjectKey{
 		Namespace: namespace,
@@ -425,7 +378,6 @@ func verifyEnvironmentVariables(t *testing.T, namespace, name string) error {
 		return fmt.Errorf("failed to get deployment: %w", err)
 	}
 
-	// Check for TLS-related environment variables
 	tlsEnvVarsFound := 0
 	expectedEnvVars := map[string]string{
 		"SSL_CERT_FILE": controllers.ManagedCABundleFilePath,
@@ -452,10 +404,7 @@ func verifyEnvironmentVariables(t *testing.T, namespace, name string) error {
 }
 
 func parseKubernetesYAML(data []byte) ([]client.Object, error) {
-	// Split YAML documents
 	docs := yamlSplit(data)
-
-	// Pre-allocate slice with expected capacity
 	objects := make([]client.Object, 0, len(docs))
 
 	for _, doc := range docs {
@@ -506,20 +455,18 @@ func waitForDeploymentCreation(t *testing.T, namespace, name string, timeout tim
 	t.Helper()
 
 	return wait.PollUntilContextTimeout(TestEnv.Ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		// First check if the LlamaStackDistribution is being processed
-		distribution := &v1alpha1.LlamaStackDistribution{}
+		server := &ogxiov1beta1.OGXServer{}
 		err := TestEnv.Client.Get(ctx, client.ObjectKey{
 			Namespace: namespace,
 			Name:      name,
-		}, distribution)
+		}, server)
 		if err != nil {
-			t.Logf("LlamaStackDistribution not found yet: %v", err)
+			t.Logf("OGXServer not found yet: %v", err)
 			return false, nil
 		}
 
-		t.Logf("LlamaStackDistribution status: Phase=%s", distribution.Status.Phase)
+		t.Logf("OGXServer status: Phase=%s", server.Status.Phase)
 
-		// Then check if the deployment has been created
 		deployment := &appsv1.Deployment{}
 		err = TestEnv.Client.Get(ctx, client.ObjectKey{
 			Namespace: namespace,

--- a/tests/e2e/validation_test.go
+++ b/tests/e2e/validation_test.go
@@ -15,12 +15,12 @@ func TestValidationSuite(t *testing.T) {
 	}
 
 	t.Run("should validate CRDs", func(t *testing.T) {
-		err := validateCRD(TestEnv.Client, TestEnv.Ctx, "llamastackdistributions.llamastack.io")
-		require.NoErrorf(t, err, "error in validating CRD: llamastackdistributions.llamastack.io")
+		err := validateCRD(TestEnv.Client, TestEnv.Ctx, "ogxservers.ogx.io")
+		require.NoErrorf(t, err, "error in validating CRD: ogxservers.ogx.io")
 	})
 
 	t.Run("should validate operator deployment", func(t *testing.T) {
-		deployment, err := GetDeployment(TestEnv.Client, TestEnv.Ctx, "llama-stack-k8s-operator-controller-manager", TestOpts.OperatorNS)
+		deployment, err := GetDeployment(TestEnv.Client, TestEnv.Ctx, "ogx-k8s-operator-controller-manager", TestOpts.OperatorNS)
 		require.NoError(t, err, "Operator deployment not found")
 		require.Equal(t, int32(1), deployment.Status.ReadyReplicas, "Operator deployment not ready")
 	})
@@ -32,7 +32,7 @@ func TestValidationSuite(t *testing.T) {
 
 		operatorPodFound := false
 		for _, pod := range podList.Items {
-			if pod.Labels["app.kubernetes.io/name"] == "llama-stack-k8s-operator" {
+			if pod.Labels["app.kubernetes.io/name"] == "ogx-k8s-operator" {
 				operatorPodFound = true
 				require.Equal(t, corev1.PodRunning, pod.Status.Phase)
 				break


### PR DESCRIPTION
- Rewrite all E2E tests from llamastack.io/v1alpha1 LlamaStackDistribution to ogx.io/v1beta1 OGXServer, updating spec structure, namespaces, and helper utilities
- Update all operator documentation (README, CONTRIBUTING, create-operator, ca-bundle-configuration) to reflect OGX naming, new CRD schema, and per-CR network policy model
- Create migration guide (docs/migration-guide.md) with step-by-step upgrade instructions, name mapping table, and rollback procedure
- Clean up residual legacy naming in pkg/deploy and controller test fixtures
- Remove stale CRD YAML (llamastack.io_llamastackdistributions.yaml)
