### PR TITLE
fix: rename distro orgs so images can pull during tests

### DIFF
--- a/distributions.json
+++ b/distributions.json
@@ -1,6 +1,6 @@
 {
-  "starter": "docker.io/llamastack/distribution-starter:latest",
-  "remote-vllm": "docker.io/llamastack/distribution-remote-vllm:latest",
-  "meta-reference-gpu": "docker.io/llamastack/distribution-meta-reference-gpu:latest",
-  "postgres-demo": "docker.io/llamastack/distribution-postgres-demo:latest"
+  "starter": "docker.io/ogxai/distribution-starter:latest",
+  "remote-vllm": "docker.io/ogxai/distribution-remote-vllm:latest",
+  "meta-reference-gpu": "docker.io/ogxai/distribution-meta-reference-gpu:latest",
+  "postgres-demo": "docker.io/ogxai/distribution-postgres-demo:latest"
 }


### PR DESCRIPTION
https://hub.docker.com/u/llamastack no longer exists, so https://hub.docker.com/u/ogxai must be used in its place.