### PR TITLE
feat: support for PrometheusRules and ServiceMonitors permission

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -44,6 +44,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -59,6 +67,19 @@ rules:
   - autoscaling
   resources:
   - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
   verbs:
   - create
   - delete

--- a/controllers/kubebuilder_rbac.go
+++ b/controllers/kubebuilder_rbac.go
@@ -46,3 +46,10 @@ package controllers
 
 // HorizontalPodAutoscaler permissions - controller creates and manages HPAs for server pods
 //+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
+
+// Monitoring permissions - controller creates and manages ServiceMonitors and PrometheusRules
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
+
+// CRD discovery - controller checks for monitoring.coreos.com CRD availability
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch

--- a/pkg/deploy/kustomizer.go
+++ b/pkg/deploy/kustomizer.go
@@ -809,3 +809,41 @@ func CheckClusterRoleExists(ctx context.Context, cli client.Client, crb *unstruc
 	}
 	return false, nil
 }
+
+// CheckCRDExists checks whether a CustomResourceDefinition is registered on the cluster.
+// Returns true if the CRD exists, false if not found.
+func CheckCRDExists(ctx context.Context, cli client.Client, crdName string) (bool, error) {
+	crd := &unstructured.Unstructured{}
+	crd.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+
+	err := cli.Get(ctx, client.ObjectKey{Name: crdName}, crd)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// MonitoringCRDsAvailable checks whether the prometheus-operator CRDs
+// (ServiceMonitor and PrometheusRule) are registered on the cluster.
+func MonitoringCRDsAvailable(ctx context.Context, cli client.Client) (bool, error) {
+	for _, crdName := range []string{
+		"servicemonitors.monitoring.coreos.com",
+		"prometheusrules.monitoring.coreos.com",
+	} {
+		exists, err := CheckCRDExists(ctx, cli, crdName)
+		if err != nil {
+			return false, fmt.Errorf("failed to check CRD %s: %w", crdName, err)
+		}
+		if !exists {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -1109,6 +1109,32 @@ func TestGetFieldMappings_RecreateStrategyWithStorage(t *testing.T) {
 	})
 }
 
+func TestCheckCRDExists(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns true for registered CRD", func(t *testing.T) {
+		exists, err := CheckCRDExists(ctx, k8sClient, "ogxservers.ogx.io")
+		require.NoError(t, err)
+		assert.True(t, exists, "ogxservers.ogx.io CRD should exist in envtest")
+	})
+
+	t.Run("returns false for non-existent CRD", func(t *testing.T) {
+		exists, err := CheckCRDExists(ctx, k8sClient, "fakes.nonexistent.example.com")
+		require.NoError(t, err)
+		assert.False(t, exists, "non-existent CRD should return false")
+	})
+}
+
+func TestMonitoringCRDsAvailable(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns false when monitoring CRDs are not installed", func(t *testing.T) {
+		available, err := MonitoringCRDsAvailable(ctx, k8sClient)
+		require.NoError(t, err)
+		assert.False(t, available, "monitoring CRDs should not be available in envtest")
+	})
+}
+
 // resourceToUnstructured converts a kustomize resource to an unstructured object.
 func resourceToUnstructured(t *testing.T, res *kresource.Resource) (*unstructured.Unstructured, error) {
 	t.Helper()

--- a/release/operator-openshift.yaml
+++ b/release/operator-openshift.yaml
@@ -6903,6 +6903,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -6918,6 +6926,19 @@ rules:
   - autoscaling
   resources:
   - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
   verbs:
   - create
   - delete

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -6904,6 +6904,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -6919,6 +6927,19 @@ rules:
   - autoscaling
   resources:
   - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
   verbs:
   - create
   - delete


### PR DESCRIPTION
Adds RBAC rules which allow for eventual Metrics / Telemetry integration.

Builds on the `CRD` support from RHAIENG-5404, which is to be implemented in #302. The code from these two PRs will be used and finalized in future tickets & PRs. 

Closes RHAIENG-5405.