### PR TITLE
feat: add registryRefreshIntervalSeconds field to OGXServer CRD

### DIFF
--- a/api/v1beta1/ogxserver_cel_test.go
+++ b/api/v1beta1/ogxserver_cel_test.go
@@ -866,6 +866,56 @@ func TestCEL_WorkloadOverrides(t *testing.T) {
 	}
 }
 
+func TestCEL_RegistryRefreshIntervalSeconds(t *testing.T) {
+	ns := createCELTestNamespace(t, "cel-regref")
+
+	tests := []struct {
+		name      string
+		mutate    func(*OGXServer)
+		wantError string
+	}{
+		{
+			name:   "field omitted is valid",
+			mutate: func(_ *OGXServer) {},
+		},
+		{
+			name: "value of 1 is valid",
+			mutate: func(o *OGXServer) {
+				o.Spec.RegistryRefreshIntervalSeconds = ptr(int32(1))
+			},
+		},
+		{
+			name: "large value is valid",
+			mutate: func(o *OGXServer) {
+				o.Spec.RegistryRefreshIntervalSeconds = ptr(int32(86400))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := validOGXServer(uniqueName(), ns)
+			tt.mutate(obj)
+			err := k8sClient.Create(context.Background(), obj)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("expected success, got: %v", err)
+				}
+				t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), obj) })
+			} else {
+				requireCELError(t, err, tt.wantError)
+			}
+		})
+	}
+
+	t.Run("value of 0 is rejected by minimum constraint", func(t *testing.T) {
+		raw := validUnstructuredOGXServer(t, uniqueName(), ns)
+		setNestedField(raw, int64(0), "spec", "registryRefreshIntervalSeconds")
+		err := createUnstructured(t, raw)
+		requireAPIError(t, err, "should be greater than or equal to 1")
+	})
+}
+
 func TestCEL_VectorIndexConfig(t *testing.T) {
 	ns := createCELTestNamespace(t, "cel-vidx")
 

--- a/api/v1beta1/ogxserver_types.go
+++ b/api/v1beta1/ogxserver_types.go
@@ -462,6 +462,12 @@ type OGXServerSpec struct {
 	// +kubebuilder:validation:MaxItems=6
 	// +kubebuilder:validation:items:Enum=batches;inference;responses;tool_runtime;vector_io;files
 	DisabledAPIs []string `json:"disabledAPIs,omitempty"`
+	// RegistryRefreshIntervalSeconds configures how often the server refreshes
+	// its model registry, in seconds. When omitted, the server's built-in
+	// default is used.
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	RegistryRefreshIntervalSeconds *int32 `json:"registryRefreshIntervalSeconds,omitempty"`
 	// Network defines network access controls.
 	// +optional
 	Network *NetworkSpec `json:"network,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1172,6 +1172,11 @@ func (in *OGXServerSpec) DeepCopyInto(out *OGXServerSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.RegistryRefreshIntervalSeconds != nil {
+		in, out := &in.RegistryRefreshIntervalSeconds, &out.RegistryRefreshIntervalSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Network != nil {
 		in, out := &in.Network, &out.Network
 		*out = new(NetworkSpec)

--- a/config/crd/bases/ogx.io_ogxservers.yaml
+++ b/config/crd/bases/ogx.io_ogxservers.yaml
@@ -3542,6 +3542,14 @@ spec:
                         type: object
                     type: object
                 type: object
+              registryRefreshIntervalSeconds:
+                description: |-
+                  RegistryRefreshIntervalSeconds configures how often the server refreshes
+                  its model registry, in seconds. When omitted, the server's built-in
+                  default is used.
+                format: int32
+                minimum: 1
+                type: integer
               resources:
                 description: |-
                   Resources declares models and tools to register.

--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -259,6 +259,13 @@ func configureContainerEnvironment(ctx context.Context, r *OGXServerReconciler, 
 		},
 	)
 
+	if instance.Spec.RegistryRefreshIntervalSeconds != nil {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "OGX_REGISTRY_REFRESH_INTERVAL_SECONDS",
+			Value: strconv.Itoa(int(*instance.Spec.RegistryRefreshIntervalSeconds)),
+		})
+	}
+
 	// Finally, add the user provided env vars
 	if instance.Spec.Workload != nil && instance.Spec.Workload.Overrides != nil {
 		container.Env = append(container.Env, instance.Spec.Workload.Overrides.Env...)

--- a/controllers/resource_helper_test.go
+++ b/controllers/resource_helper_test.go
@@ -99,6 +99,37 @@ func TestBuildContainerSpec(t *testing.T) {
 		}
 		assert.Contains(t, envNames, "TEST_ENV")
 	})
+
+	t.Run("registryRefreshIntervalSeconds not set", func(t *testing.T) {
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+			},
+		}
+		c := buildContainerSpec(t.Context(), nil, instance, "test-image:latest")
+		for _, e := range c.Env {
+			assert.NotEqual(t, "OGX_REGISTRY_REFRESH_INTERVAL_SECONDS", e.Name)
+		}
+	})
+
+	t.Run("registryRefreshIntervalSeconds set", func(t *testing.T) {
+		val := int32(30)
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution:                   ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+				RegistryRefreshIntervalSeconds: &val,
+			},
+		}
+		c := buildContainerSpec(t.Context(), nil, instance, "test-image:latest")
+		var found bool
+		for _, e := range c.Env {
+			if e.Name == "OGX_REGISTRY_REFRESH_INTERVAL_SECONDS" {
+				assert.Equal(t, "30", e.Value)
+				found = true
+			}
+		}
+		assert.True(t, found, "expected OGX_REGISTRY_REFRESH_INTERVAL_SECONDS env var")
+	})
 }
 
 func TestResolveImage(t *testing.T) {

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -811,6 +811,7 @@ _Appears in:_
 | `resources` _[ResourcesSpec](#resourcesspec)_ | Resources declares models and tools to register.<br />Mutually exclusive with overrideConfig. |  |  |
 | `storage` _[StateStorageSpec](#statestoragespec)_ | Storage configures state storage backends (KV and SQL).<br />Mutually exclusive with overrideConfig. |  |  |
 | `disabledAPIs` _string array_ | DisabledAPIs lists API names to remove from the generated config.<br />Mutually exclusive with overrideConfig. |  | MaxItems: 6 <br />MinItems: 1 <br />items:Enum: [batches inference responses tool_runtime vector_io files] <br /> |
+| `registryRefreshIntervalSeconds` _integer_ | RegistryRefreshIntervalSeconds configures how often the server refreshes<br />its model registry, in seconds. When omitted, the server's built-in<br />default is used. |  | Minimum: 1 <br /> |
 | `network` _[NetworkSpec](#networkspec)_ | Network defines network access controls. |  |  |
 | `tls` _[TLSClientConfig](#tlsclientconfig)_ | TLS configures outbound TLS trust anchors and client identity for<br />connections to providers and backends. |  |  |
 | `workload` _[WorkloadSpec](#workloadspec)_ | Workload consolidates Kubernetes deployment settings. |  |  |

--- a/release/operator-openshift.yaml
+++ b/release/operator-openshift.yaml
@@ -3551,6 +3551,14 @@ spec:
                         type: object
                     type: object
                 type: object
+              registryRefreshIntervalSeconds:
+                description: |-
+                  RegistryRefreshIntervalSeconds configures how often the server refreshes
+                  its model registry, in seconds. When omitted, the server's built-in
+                  default is used.
+                format: int32
+                minimum: 1
+                type: integer
               resources:
                 description: |-
                   Resources declares models and tools to register.

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -3552,6 +3552,14 @@ spec:
                         type: object
                     type: object
                 type: object
+              registryRefreshIntervalSeconds:
+                description: |-
+                  RegistryRefreshIntervalSeconds configures how often the server refreshes
+                  its model registry, in seconds. When omitted, the server's built-in
+                  default is used.
+                format: int32
+                minimum: 1
+                type: integer
               resources:
                 description: |-
                   Resources declares models and tools to register.


### PR DESCRIPTION
## Summary

- Adds an optional `spec.registryRefreshIntervalSeconds` field (`*int32`, minimum 1) to the OGXServer CRD for configuring the model registry refresh interval
- Passes the value as `OGX_REGISTRY_REFRESH_INTERVAL_SECONDS` env var to the container; omitted when unset so the server's built-in default applies
- Includes unit tests for env var emission and schema validation tests for the minimum constraint

Ref: RHAIENG-5504

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (unit + integration)
- [ ] Deploy operator with a CR setting `registryRefreshIntervalSeconds: 60` and verify the env var appears on the pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)