### PR TITLE
fix: Add ReplicaSet cache and RBAC access for generated config cleanup

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -64,6 +64,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers

--- a/controllers/kubebuilder_rbac.go
+++ b/controllers/kubebuilder_rbac.go
@@ -7,6 +7,8 @@ package controllers
 
 // Deployment permissions - controller creates and manages deployments
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// ReplicaSet permissions - controller lists rollout history to retain referenced generated configmaps
+//+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch
 
 // Service permissions - controller creates and manages services
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete

--- a/main.go
+++ b/main.go
@@ -114,7 +114,6 @@ func newCacheOptions() cache.Options {
 				}),
 			},
 			&appsv1.Deployment{}:                     managedByFilter,
-			&appsv1.ReplicaSet{}:                     managedByFilter,
 			&policyv1.PodDisruptionBudget{}:          managedByFilter,
 			&autoscalingv2.HorizontalPodAutoscaler{}: managedByFilter,
 			&corev1.Service{}:                        managedByFilter,

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func newCacheOptions() cache.Options {
 				}),
 			},
 			&appsv1.Deployment{}:                     managedByFilter,
+			&appsv1.ReplicaSet{}:                     managedByFilter,
 			&policyv1.PodDisruptionBudget{}:          managedByFilter,
 			&autoscalingv2.HorizontalPodAutoscaler{}: managedByFilter,
 			&corev1.Service{}:                        managedByFilter,

--- a/release/operator-openshift.yaml
+++ b/release/operator-openshift.yaml
@@ -6923,6 +6923,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -6924,6 +6924,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers


### PR DESCRIPTION
Generated config cleanup lists ReplicaSets to preserve ConfigMaps still referenced by in-flight rollouts. Add ReplicaSet cache coverage and RBAC so that lookup works reliably under the controller-runtime cached client.