### PR TITLE
refactor: add necessary  image placeholders for disconnected

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,6 +56,14 @@ spec:
           value: "800MiB"
         - name: OPERATOR_VERSION
           value: "latest"
+        - name: RELATED_IMAGE_STARTER
+          value: ""
+        - name: RELATED_IMAGE_REMOTE_VLLM
+          value: ""
+        - name: RELATED_IMAGE_META_REFERENCE_GPU
+          value: ""
+        - name: RELATED_IMAGE_POSTGRES_DEMO
+          value: ""
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/ogx-ai/ogx-k8s-operator/pkg/deploy"
@@ -30,10 +32,29 @@ func NewClusterInfo(ctx context.Context, client client.Client, embeddedDistribut
 		return nil, fmt.Errorf("failed to parse embedded distributions JSON: %w", err)
 	}
 
+	applyRelatedImageOverrides(distributionImages)
+
 	return &ClusterInfo{
 		OperatorNamespace:  operatorNamespace,
 		DistributionImages: distributionImages,
 	}, nil
+}
+
+// applyRelatedImageOverrides overrides distribution images with RELATED_IMAGE_* env vars
+// when set. OLM injects these with mirrored image digests for disconnected environments.
+func applyRelatedImageOverrides(distributionImages map[string]string) {
+	for name := range distributionImages {
+		envKey := DistributionEnvVarKey(name)
+		if override := os.Getenv(envKey); override != "" {
+			distributionImages[name] = override
+		}
+	}
+}
+
+// DistributionEnvVarKey converts a distribution name to its RELATED_IMAGE_* env var name.
+// Example: "remote-vllm" becomes "RELATED_IMAGE_REMOTE_VLLM".
+func DistributionEnvVarKey(name string) string {
+	return "RELATED_IMAGE_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
 }
 
 // PerformUpgradeCleanup performs one-time cleanup operations for seamless upgrades.

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestDistributionsJSONIsValid ensures that the distributions.json file always
@@ -27,4 +29,79 @@ func TestDistributionsJSONIsValid(t *testing.T) {
 			t.Fatalf("failed to validate distributions.json: contains an empty value for key %q", k)
 		}
 	}
+}
+
+func TestDistributionEnvVarKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{name: "starter", expected: "RELATED_IMAGE_STARTER"},
+		{name: "remote-vllm", expected: "RELATED_IMAGE_REMOTE_VLLM"},
+		{name: "meta-reference-gpu", expected: "RELATED_IMAGE_META_REFERENCE_GPU"},
+		{name: "postgres-demo", expected: "RELATED_IMAGE_POSTGRES_DEMO"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, DistributionEnvVarKey(tt.name))
+		})
+	}
+}
+
+func TestNewClusterInfoRelatedImageOverrides(t *testing.T) {
+	distributions := `{
+		"starter": "docker.io/ogxai/distribution-starter:latest",
+		"remote-vllm": "docker.io/ogxai/distribution-remote-vllm:latest",
+		"meta-reference-gpu": "docker.io/ogxai/distribution-meta-reference-gpu:latest"
+	}`
+
+	t.Run("no env vars set uses distributions.json defaults", func(t *testing.T) {
+		var images map[string]string
+		require.NoError(t, json.Unmarshal([]byte(distributions), &images))
+
+		applyRelatedImageOverrides(images)
+
+		require.Equal(t, "docker.io/ogxai/distribution-starter:latest", images["starter"])
+		require.Equal(t, "docker.io/ogxai/distribution-remote-vllm:latest", images["remote-vllm"])
+		require.Equal(t, "docker.io/ogxai/distribution-meta-reference-gpu:latest", images["meta-reference-gpu"])
+	})
+
+	t.Run("env var overrides single distribution", func(t *testing.T) {
+		t.Setenv("RELATED_IMAGE_STARTER", "mirror.example.com/ogx-starter@sha256:abc123")
+
+		var images map[string]string
+		require.NoError(t, json.Unmarshal([]byte(distributions), &images))
+
+		applyRelatedImageOverrides(images)
+
+		require.Equal(t, "mirror.example.com/ogx-starter@sha256:abc123", images["starter"])
+		require.Equal(t, "docker.io/ogxai/distribution-remote-vllm:latest", images["remote-vllm"])
+	})
+
+	t.Run("env var overrides all distributions", func(t *testing.T) {
+		t.Setenv("RELATED_IMAGE_STARTER", "mirror.example.com/starter@sha256:aaa")
+		t.Setenv("RELATED_IMAGE_REMOTE_VLLM", "mirror.example.com/vllm@sha256:bbb")
+		t.Setenv("RELATED_IMAGE_META_REFERENCE_GPU", "mirror.example.com/gpu@sha256:ccc")
+
+		var images map[string]string
+		require.NoError(t, json.Unmarshal([]byte(distributions), &images))
+
+		applyRelatedImageOverrides(images)
+
+		require.Equal(t, "mirror.example.com/starter@sha256:aaa", images["starter"])
+		require.Equal(t, "mirror.example.com/vllm@sha256:bbb", images["remote-vllm"])
+		require.Equal(t, "mirror.example.com/gpu@sha256:ccc", images["meta-reference-gpu"])
+	})
+
+	t.Run("empty env var does not override", func(t *testing.T) {
+		t.Setenv("RELATED_IMAGE_STARTER", "")
+
+		var images map[string]string
+		require.NoError(t, json.Unmarshal([]byte(distributions), &images))
+
+		applyRelatedImageOverrides(images)
+
+		require.Equal(t, "docker.io/ogxai/distribution-starter:latest", images["starter"])
+	})
 }

--- a/release/operator-openshift.yaml
+++ b/release/operator-openshift.yaml
@@ -7277,6 +7277,14 @@ spec:
           value: 800MiB
         - name: OPERATOR_VERSION
           value: latest
+        - name: RELATED_IMAGE_STARTER
+          value: ""
+        - name: RELATED_IMAGE_REMOTE_VLLM
+          value: ""
+        - name: RELATED_IMAGE_META_REFERENCE_GPU
+          value: ""
+        - name: RELATED_IMAGE_POSTGRES_DEMO
+          value: ""
         image: quay.io/ogx-ai/ogx-k8s-operator:latest
         imagePullPolicy: Always
         livenessProbe:

--- a/release/operator.yaml
+++ b/release/operator.yaml
@@ -7276,6 +7276,14 @@ spec:
           value: 800MiB
         - name: OPERATOR_VERSION
           value: latest
+        - name: RELATED_IMAGE_STARTER
+          value: ""
+        - name: RELATED_IMAGE_REMOTE_VLLM
+          value: ""
+        - name: RELATED_IMAGE_META_REFERENCE_GPU
+          value: ""
+        - name: RELATED_IMAGE_POSTGRES_DEMO
+          value: ""
         image: quay.io/ogx-ai/ogx-k8s-operator:latest
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
Addressing the disconnected scanner results from https://github.com/opendatahub-io/disconnected-readiness-scorer/actions/runs/27770487578. The remediation documentation for that is located at https://github.com/opendatahub-io/disconnected-readiness-scorer/blob/main/docs/remediation-guide.md.

Adds generic `RELATED_IMAGE_*` environment variable override support so OLM can inject mirrored image digests in disconnected/air-gapped OpenShift  clusters. 

This addresses disconnected readiness scanner findings (`image-manifest-complete` and `params-env-wiring` blockers) by following the standard OLM `RELATED_IMAGE` pattern. When no env vars are set, behavior is unchanged.

Closes `RHOAIENG-70001`