### PR TITLE
ci: add Mergify rule to auto-update PRs behind main

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,4 +1,14 @@
 pull_request_rules:
+- name: keep PRs up to date with main
+  conditions:
+    - -conflict
+    - -draft
+    - -closed
+    - -merged
+    - label!=do-not-merge
+  actions:
+    update: {}
+
 - name: auto-merge GitHub Actions dependency bumps
   description: >
     Automatic merge of GitHub Actions dependency bump PRs with 1 approval


### PR DESCRIPTION
## Summary
- Adds a Mergify rule to automatically update non-draft, non-conflicting PRs when they fall behind main
- Mirrors the change from [ogx-distribution#453](https://github.com/opendatahub-io/ogx-distribution/pull/453)

## Test plan
- [ ] Verify Mergify picks up the new rule after merge
- [ ] Confirm PRs behind main get auto-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)