### PR TITLE
fix: preserve image entrypoint when using overrideConfig

### DIFF
--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -300,22 +300,27 @@ func configureContainerEnvironment(
 		container.Env = append(container.Env, secretEnvVars...)
 	}
 
-	// Apply user-provided env vars, letting them override operator defaults.
-	if instance.Spec.Workload != nil && instance.Spec.Workload.Overrides != nil {
-		overrides := make(map[string]corev1.EnvVar, len(instance.Spec.Workload.Overrides.Env))
-		for _, e := range instance.Spec.Workload.Overrides.Env {
-			overrides[e.Name] = e
-		}
-		deduped := make([]corev1.EnvVar, 0, len(container.Env))
-		for _, e := range container.Env {
-			if _, ok := overrides[e.Name]; ok {
-				continue
-			}
-			deduped = append(deduped, e)
-		}
-		deduped = append(deduped, instance.Spec.Workload.Overrides.Env...)
-		container.Env = deduped
+	applyEnvOverrides(instance, container)
+}
+
+// applyEnvOverrides merges user-provided env vars, letting them override operator defaults.
+func applyEnvOverrides(instance *ogxiov1beta1.OGXServer, container *corev1.Container) {
+	if instance.Spec.Workload == nil || instance.Spec.Workload.Overrides == nil {
+		return
 	}
+	overrides := make(map[string]corev1.EnvVar, len(instance.Spec.Workload.Overrides.Env))
+	for _, e := range instance.Spec.Workload.Overrides.Env {
+		overrides[e.Name] = e
+	}
+	deduped := make([]corev1.EnvVar, 0, len(container.Env))
+	for _, e := range container.Env {
+		if _, ok := overrides[e.Name]; ok {
+			continue
+		}
+		deduped = append(deduped, e)
+	}
+	deduped = append(deduped, instance.Spec.Workload.Overrides.Env...)
+	container.Env = deduped
 }
 
 // configureContainerMounts sets up volume mounts for the container.

--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -86,51 +86,6 @@ func getManagedCABundleConfigMapName(instance *ogxiov1beta1.OGXServer) string {
 	return instance.Name + ManagedCABundleConfigMapSuffix
 }
 
-// startupScript is the script that will be used to start the server.
-var startupScript = `
-set -e
-
-# Determine which CLI to use based on ogx version
-VERSION_CODE=$(python -c "
-import sys
-from importlib.metadata import version
-from packaging import version as pkg_version
-
-try:
-    ogx_version = version('ogx')
-    print(f'Detected ogx version: {ogx_version}', file=sys.stderr)
-
-    v = pkg_version.parse(ogx_version)
-    # Use base_version to ignore pre-release/post-release/dev suffixes
-    # This ensures that 0.3.0rc2, 0.3.0alpha1, etc. are treated as 0.3.0
-    base_v = pkg_version.parse(v.base_version)
-
-    if base_v < pkg_version.parse('0.2.17'):
-        print('Using legacy module path (ogx.distribution.server.server)', file=sys.stderr)
-        print(0)
-    elif base_v < pkg_version.parse('0.3.0'):
-        print('Using core module path (ogx.core.server.server)', file=sys.stderr)
-        print(1)
-    else:
-        print('Using uvicorn CLI command', file=sys.stderr)
-        print(2)
-except Exception as e:
-    print(f'Version detection failed, defaulting to new CLI: {e}', file=sys.stderr)
-    print(2)
-")
-
-PORT=${OGX_PORT:-8321}
-WORKERS=${OGX_WORKERS:-1}
-
-# Execute the appropriate CLI based on version
-case $VERSION_CODE in
-    0) python3 -m ogx.distribution.server.server --config /etc/ogx/config.yaml ;;
-    1) python3 -m ogx.core.server.server /etc/ogx/config.yaml ;;
-    2) exec uvicorn ogx.core.server.server:create_app --host 0.0.0.0 --port "$PORT" --workers "$WORKERS" --factory ;;
-    *) echo "Invalid version code: $VERSION_CODE, using uvicorn CLI command"; \
-       exec uvicorn ogx.core.server.server:create_app --host 0.0.0.0 --port "$PORT" --workers "$WORKERS" --factory ;;
-esac`
-
 const ogxConfigPath = "/etc/ogx/config.yaml"
 
 // getHealthProbe returns the health probe handler for the container.
@@ -171,7 +126,7 @@ func buildContainerSpec(
 		Ports:        []corev1.ContainerPort{{ContainerPort: getContainerPort(instance)}},
 		StartupProbe: getStartupProbe(instance),
 	}
-	configureContainerEnvironment(ctx, r, instance, &container, secretEnvVars)
+	configureContainerEnvironment(ctx, r, instance, &container, runtimeConfig, secretEnvVars)
 	configureContainerMounts(ctx, r, instance, runtimeConfig, &container)
 	configureContainerCommands(instance, runtimeConfig, &container)
 	return container
@@ -253,7 +208,10 @@ func getEffectiveWorkers(instance *ogxiov1beta1.OGXServer) (int32, bool) {
 }
 
 // configureContainerEnvironment sets up environment variables for the container.
-func configureContainerEnvironment(ctx context.Context, r *OGXServerReconciler, instance *ogxiov1beta1.OGXServer, container *corev1.Container, secretEnvVars []corev1.EnvVar) {
+func configureContainerEnvironment(
+	ctx context.Context, r *OGXServerReconciler, instance *ogxiov1beta1.OGXServer,
+	container *corev1.Container, runtimeConfig *runtimeConfigRef, secretEnvVars []corev1.EnvVar,
+) {
 	mountPath := getMountPath(instance)
 	workers, _ := getEffectiveWorkers(instance)
 
@@ -275,7 +233,6 @@ func configureContainerEnvironment(ctx context.Context, r *OGXServerReconciler, 
 		})
 	}
 
-	// Always provide worker/port/config env for uvicorn; workers default to 1 when unspecified.
 	container.Env = append(container.Env,
 		corev1.EnvVar{
 			Name:  "OGX_WORKERS",
@@ -285,11 +242,22 @@ func configureContainerEnvironment(ctx context.Context, r *OGXServerReconciler, 
 			Name:  "OGX_PORT",
 			Value: strconv.Itoa(int(getContainerPort(instance))),
 		},
-		corev1.EnvVar{
-			Name:  "OGX_CONFIG",
-			Value: ogxConfigPath,
-		},
 	)
+
+	// Point the image entrypoint at the mounted config when a runtime
+	// config (overrideConfig or operator-generated) is in use.
+	if runtimeConfig != nil {
+		container.Env = append(container.Env,
+			corev1.EnvVar{
+				Name:  "RUN_CONFIG_PATH",
+				Value: ogxConfigPath,
+			},
+			corev1.EnvVar{
+				Name:  "OGX_CONFIG",
+				Value: ogxConfigPath,
+			},
+		)
+	}
 
 	if instance.Spec.RegistryRefreshIntervalSeconds != nil {
 		container.Env = append(container.Env, corev1.EnvVar{
@@ -359,12 +327,7 @@ func hasAnyCABundle(ctx context.Context, r *OGXServerReconciler, instance *ogxio
 }
 
 // configureContainerCommands sets up container commands and args.
-func configureContainerCommands(instance *ogxiov1beta1.OGXServer, runtimeConfig *runtimeConfigRef, container *corev1.Container) {
-	if runtimeConfig != nil {
-		container.Command = []string{"/bin/sh", "-c", startupScript}
-		container.Args = []string{}
-	}
-
+func configureContainerCommands(instance *ogxiov1beta1.OGXServer, _ *runtimeConfigRef, container *corev1.Container) {
 	// Apply user-specified command and args (takes precedence)
 	if instance.Spec.Workload != nil && instance.Spec.Workload.Overrides != nil {
 		if len(instance.Spec.Workload.Overrides.Command) > 0 {

--- a/controllers/resource_helper_test.go
+++ b/controllers/resource_helper_test.go
@@ -281,6 +281,46 @@ func TestNeedsPodDisruptionBudget(t *testing.T) {
 	}
 }
 
+func TestBuildContainerSpecRuntimeConfig(t *testing.T) {
+	t.Run("runtimeConfig sets RUN_CONFIG_PATH and preserves entrypoint", func(t *testing.T) {
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+			},
+		}
+		rc := &runtimeConfigRef{ConfigMapName: "my-config", ConfigMapKey: "config.yaml"}
+		c := buildContainerSpec(t.Context(), nil, instance, "test-image:latest", rc, nil)
+
+		var foundRunConfig, foundOgxConfig bool
+		for _, e := range c.Env {
+			if e.Name == "RUN_CONFIG_PATH" {
+				assert.Equal(t, "/etc/ogx/config.yaml", e.Value)
+				foundRunConfig = true
+			}
+			if e.Name == "OGX_CONFIG" {
+				assert.Equal(t, "/etc/ogx/config.yaml", e.Value)
+				foundOgxConfig = true
+			}
+		}
+		assert.True(t, foundRunConfig, "expected RUN_CONFIG_PATH env var when runtimeConfig is set")
+		assert.True(t, foundOgxConfig, "expected OGX_CONFIG env var when runtimeConfig is set")
+		assert.Nil(t, c.Command, "container command should not be overridden when runtimeConfig is set")
+	})
+
+	t.Run("no runtimeConfig omits RUN_CONFIG_PATH and OGX_CONFIG", func(t *testing.T) {
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+			},
+		}
+		c := buildContainerSpec(t.Context(), nil, instance, "test-image:latest", nil, nil)
+		for _, e := range c.Env {
+			assert.NotEqual(t, "RUN_CONFIG_PATH", e.Name, "RUN_CONFIG_PATH should not be set without runtimeConfig")
+			assert.NotEqual(t, "OGX_CONFIG", e.Name, "OGX_CONFIG should not be set without runtimeConfig")
+		}
+	})
+}
+
 func TestBuildPodDisruptionBudgetSpec(t *testing.T) {
 	t.Run("defaults when replicas > 1", func(t *testing.T) {
 		inst := &ogxiov1beta1.OGXServer{


### PR DESCRIPTION
## Summary
- Stop replacing the container entrypoint with an inline startup script when overrideConfig is used
- Instead, set `RUN_CONFIG_PATH` and `OGX_CONFIG` env vars so the image's own entrypoint handles config selection
- Preserves OTEL auto-instrumentation and eliminates a divergent startup code path

## Details

When an OGXServer uses `overrideConfig`, the operator was replacing the container's entrypoint with a 45-line inline bash script that did version detection and direct uvicorn invocation. This bypassed the image's `entrypoint.sh`, losing OTEL wrapping and creating two divergent startup paths.

The fix lets the image entrypoint run normally and controls behavior via env vars:
- `RUN_CONFIG_PATH=/etc/ogx/config.yaml` - tells the entrypoint to use the mounted config
- `OGX_CONFIG=/etc/ogx/config.yaml` - used by `server.py:create_app()` factory

Both upstream and downstream container images already support `RUN_CONFIG_PATH` in their entrypoints.

Depends on [ogx#6221](https://github.com/ogx-ai/ogx/pull/6221) for `OGX_WORKERS` env var support (so worker count remains controllable via the CR spec).

Breaks backward compatibility with pre-0.3.0 (pre-rename) images - they didn't have the ogx module name and are already non-functional.

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Verified on live cluster: with overrideConfig, PID 1 = `ogx run /etc/ogx/config.yaml`, OTEL active
- [x] Verified on live cluster: without overrideConfig, entrypoint uses baked-in config, no stale `OGX_CONFIG` env var