### PR TITLE
feat: add ServiceMonitor, PrometheusRule, and metrics NetworkPolicy

### DIFF
--- a/controllers/manifests/base/kustomization.yaml
+++ b/controllers/manifests/base/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
 - hpa.yaml
 - pdb.yaml
 - rolebinding.yaml
+- prometheusrule.yaml
+- servicemonitor.yaml
 
 labels:
 - includeSelectors: false

--- a/controllers/manifests/base/prometheusrule.yaml
+++ b/controllers/manifests/base/prometheusrule.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prometheus-rules
+spec:
+  groups:
+  - name: ogx.rules
+    interval: 60s
+    rules:
+    - record: ogx:api_info
+      labels:
+        api: inference
+      expr: clamp_max(sum(ogx_requests_total{api="inference"}) or vector(0), 1)
+    - record: ogx:api_info
+      labels:
+        api: vector_io
+      expr: clamp_max(sum(ogx_requests_total{api="vector_io"}) or vector(0), 1)
+    - record: ogx:api_info
+      labels:
+        api: responses
+      expr: clamp_max(sum(ogx_requests_total{api="responses"}) or vector(0), 1)
+    - record: ogx:api_info
+      labels:
+        api: rag
+      expr: clamp_max(sum(ogx_vector_io_queries_total) or vector(0), 1)
+    - record: ogx:api_info
+      labels:
+        api: agentic
+      expr: clamp_max(sum(ogx_tool_runtime_invocations_total) or vector(0), 1)

--- a/controllers/manifests/base/servicemonitor.yaml
+++ b/controllers/manifests/base/servicemonitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: service-monitor
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: ogx-operator
+      app.kubernetes.io/part-of: ogx
+  endpoints:
+  - targetPort: 9464
+    path: /v1/metrics
+    interval: 60s

--- a/controllers/ogxserver_controller.go
+++ b/controllers/ogxserver_controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ogx-ai/ogx-k8s-operator/pkg/cluster"
 	"github.com/ogx-ai/ogx-k8s-operator/pkg/config"
 	"github.com/ogx-ai/ogx-k8s-operator/pkg/deploy"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -49,6 +50,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -244,6 +246,10 @@ func (r *OGXServerReconciler) determineKindsToExclude(instance *ogxiov1beta1.OGX
 		kinds = append(kinds, "HorizontalPodAutoscaler")
 	}
 
+	if isMonitoringDisabled(instance) {
+		kinds = append(kinds, "PrometheusRule", "ServiceMonitor")
+	}
+
 	return kinds
 }
 
@@ -282,6 +288,17 @@ func (r *OGXServerReconciler) reconcileAllManifestResources(
 	}
 
 	kindsToExclude := r.determineKindsToExclude(instance, effectivePVCName)
+
+	if !slices.Contains(kindsToExclude, "PrometheusRule") {
+		monitoringAvailable, monErr := deploy.MonitoringCRDsAvailable(ctx, r.Client)
+		if monErr != nil {
+			return fmt.Errorf("failed to check monitoring CRD availability: %w", monErr)
+		}
+		if !monitoringAvailable {
+			kindsToExclude = append(kindsToExclude, "PrometheusRule", "ServiceMonitor")
+		}
+	}
+
 	filteredResMap, err := deploy.FilterExcludeKinds(resMap, kindsToExclude)
 	if err != nil {
 		return fmt.Errorf("failed to filter manifests: %w", err)
@@ -324,6 +341,10 @@ func (r *OGXServerReconciler) deleteExcludedResources(ctx context.Context, insta
 			logger.Error(err, "Failed to delete HorizontalPodAutoscaler")
 			return err
 		}
+	}
+
+	if err := r.deleteMonitoringResourcesIfExcluded(ctx, instance, kindsToExclude); err != nil {
+		return err
 	}
 
 	return nil
@@ -408,6 +429,80 @@ func (r *OGXServerReconciler) deleteHorizontalPodAutoscalerIfExists(ctx context.
 	logger.Info("Deleting HorizontalPodAutoscaler as feature is disabled", "hpa", hpaName)
 	if err := r.Delete(ctx, hpa); err != nil {
 		return fmt.Errorf("failed to delete HorizontalPodAutoscaler: %w", err)
+	}
+
+	return nil
+}
+
+func (r *OGXServerReconciler) deleteMonitoringResourcesIfExcluded(ctx context.Context, instance *ogxiov1beta1.OGXServer, kindsToExclude []string) error {
+	logger := log.FromContext(ctx)
+
+	if slices.Contains(kindsToExclude, "PrometheusRule") {
+		if err := r.deletePrometheusRuleIfExists(ctx, instance); err != nil {
+			logger.Error(err, "Failed to delete PrometheusRule")
+			return err
+		}
+	}
+
+	if slices.Contains(kindsToExclude, "ServiceMonitor") {
+		if err := r.deleteServiceMonitorIfExists(ctx, instance); err != nil {
+			logger.Error(err, "Failed to delete ServiceMonitor")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *OGXServerReconciler) deletePrometheusRuleIfExists(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
+	logger := log.FromContext(ctx)
+
+	promRule := &monitoringv1.PrometheusRule{}
+	promRuleName := instance.Name + "-prometheus-rules"
+	key := types.NamespacedName{Name: promRuleName, Namespace: instance.Namespace}
+
+	if err := r.Get(ctx, key, promRule); err != nil {
+		if k8serrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get PrometheusRule: %w", err)
+	}
+
+	if !metav1.IsControlledBy(promRule, instance) {
+		logger.V(1).Info("PrometheusRule not owned by this instance, skipping deletion", "prometheusRule", promRuleName)
+		return nil
+	}
+
+	logger.Info("Deleting PrometheusRule as monitoring is disabled", "prometheusRule", promRuleName)
+	if err := r.Delete(ctx, promRule); err != nil {
+		return fmt.Errorf("failed to delete PrometheusRule: %w", err)
+	}
+
+	return nil
+}
+
+func (r *OGXServerReconciler) deleteServiceMonitorIfExists(ctx context.Context, instance *ogxiov1beta1.OGXServer) error {
+	logger := log.FromContext(ctx)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	smName := instance.Name + "-service-monitor"
+	key := types.NamespacedName{Name: smName, Namespace: instance.Namespace}
+
+	if err := r.Get(ctx, key, sm); err != nil {
+		if k8serrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get ServiceMonitor: %w", err)
+	}
+
+	if !metav1.IsControlledBy(sm, instance) {
+		logger.V(1).Info("ServiceMonitor not owned by this instance, skipping deletion", "serviceMonitor", smName)
+		return nil
+	}
+
+	logger.Info("Deleting ServiceMonitor as monitoring is disabled", "serviceMonitor", smName)
+	if err := r.Delete(ctx, sm); err != nil {
+		return fmt.Errorf("failed to delete ServiceMonitor: %w", err)
 	}
 
 	return nil

--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -40,6 +40,8 @@ const (
 	FSGroup = int64(1001)
 	// instanceLabelKey is the label we apply to all resources for per-instance targeting.
 	instanceLabelKey = "app.kubernetes.io/instance"
+	// defaultMetricsPort is the default port for the OGX metrics endpoint.
+	defaultMetricsPort = int32(9464)
 )
 
 var (
@@ -154,6 +156,17 @@ func getStartupProbe(instance *ogxiov1beta1.OGXServer) *corev1.Probe {
 	}
 }
 
+func isMonitoringDisabled(instance *ogxiov1beta1.OGXServer) bool {
+	return instance.Spec.Monitoring != nil && instance.Spec.Monitoring.Enabled != nil && !*instance.Spec.Monitoring.Enabled
+}
+
+func getMetricsPort(instance *ogxiov1beta1.OGXServer) int32 {
+	if instance.Spec.Monitoring != nil && instance.Spec.Monitoring.MetricsPort != nil {
+		return *instance.Spec.Monitoring.MetricsPort
+	}
+	return defaultMetricsPort
+}
+
 // buildContainerSpec creates the container specification.
 func buildContainerSpec(
 	ctx context.Context,
@@ -164,11 +177,18 @@ func buildContainerSpec(
 	secretEnvVars []corev1.EnvVar,
 ) corev1.Container {
 	workers, workersSet := getEffectiveWorkers(instance)
+	ports := []corev1.ContainerPort{{ContainerPort: getContainerPort(instance)}}
+	if !isMonitoringDisabled(instance) {
+		ports = append(ports, corev1.ContainerPort{
+			Name:          "metrics",
+			ContainerPort: getMetricsPort(instance),
+		})
+	}
 	container := corev1.Container{
 		Name:         ogxiov1beta1.DefaultContainerName,
 		Image:        image,
 		Resources:    resolveContainerResources(instance, workers, workersSet),
-		Ports:        []corev1.ContainerPort{{ContainerPort: getContainerPort(instance)}},
+		Ports:        ports,
 		StartupProbe: getStartupProbe(instance),
 	}
 	configureContainerEnvironment(ctx, r, instance, &container, secretEnvVars)
@@ -297,6 +317,15 @@ func configureContainerEnvironment(ctx context.Context, r *OGXServerReconciler, 
 			Value: strconv.Itoa(int(*instance.Spec.RegistryRefreshIntervalSeconds)),
 		})
 	}
+
+	if !isMonitoringDisabled(instance) {
+		container.Env = append(container.Env,
+			corev1.EnvVar{Name: "OGX_METRICS_ENDPOINT_ENABLED", Value: "1"},
+			corev1.EnvVar{Name: "OGX_METRICS_HOST", Value: "0.0.0.0"},
+			corev1.EnvVar{Name: "OGX_METRICS_PORT", Value: strconv.Itoa(int(getMetricsPort(instance)))},
+		)
+	}
+
 	// Inject pre-computed secret env vars for provider/storage references.
 	// These are computed once in buildManifestContext to avoid redundant tree walks.
 	if len(secretEnvVars) > 0 {

--- a/controllers/resource_helper_test.go
+++ b/controllers/resource_helper_test.go
@@ -60,6 +60,9 @@ func TestBuildContainerSpec(t *testing.T) {
 		assert.Equal(t, ogxiov1beta1.DefaultContainerName, c.Name)
 		assert.Equal(t, "test-image:latest", c.Image)
 		assert.Equal(t, ogxiov1beta1.DefaultServerPort, c.Ports[0].ContainerPort)
+		require.Len(t, c.Ports, 2, "expected API + metrics ports by default")
+		assert.Equal(t, int32(9464), c.Ports[1].ContainerPort)
+		assert.Equal(t, "metrics", c.Ports[1].Name)
 		assert.Equal(t, newDefaultStartupProbe(ogxiov1beta1.DefaultServerPort), c.StartupProbe)
 		var foundOgxVol bool
 		for _, m := range c.VolumeMounts {
@@ -167,6 +170,101 @@ func TestContainerEnvVarDedup(t *testing.T) {
 			break
 		}
 	}
+}
+
+func TestMetricsEnvVarsAndPort(t *testing.T) {
+	metricsEnvNames := []string{"OGX_METRICS_ENDPOINT_ENABLED", "OGX_METRICS_HOST", "OGX_METRICS_PORT"}
+
+	findEnv := func(envs []corev1.EnvVar, name string) (string, bool) {
+		for _, e := range envs {
+			if e.Name == name {
+				return e.Value, true
+			}
+		}
+		return "", false
+	}
+
+	t.Run("monitoring nil means enabled by default", func(t *testing.T) {
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+			},
+		}
+		c := buildContainerSpec(t.Context(), nil, instance, "img", nil, nil)
+		for _, name := range metricsEnvNames {
+			_, found := findEnv(c.Env, name)
+			assert.True(t, found, "expected %s when monitoring is nil", name)
+		}
+		v, _ := findEnv(c.Env, "OGX_METRICS_HOST")
+		assert.Equal(t, "0.0.0.0", v)
+		v, _ = findEnv(c.Env, "OGX_METRICS_PORT")
+		assert.Equal(t, "9464", v)
+		require.Len(t, c.Ports, 2)
+		assert.Equal(t, int32(9464), c.Ports[1].ContainerPort)
+	})
+
+	t.Run("monitoring explicitly enabled", func(t *testing.T) {
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+				Monitoring:   &ogxiov1beta1.MonitoringSpec{Enabled: boolPtr(true)},
+			},
+		}
+		c := buildContainerSpec(t.Context(), nil, instance, "img", nil, nil)
+		for _, name := range metricsEnvNames {
+			_, found := findEnv(c.Env, name)
+			assert.True(t, found, "expected %s when monitoring enabled", name)
+		}
+		require.Len(t, c.Ports, 2)
+	})
+
+	t.Run("monitoring disabled", func(t *testing.T) {
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+				Monitoring:   &ogxiov1beta1.MonitoringSpec{Enabled: boolPtr(false)},
+			},
+		}
+		c := buildContainerSpec(t.Context(), nil, instance, "img", nil, nil)
+		for _, name := range metricsEnvNames {
+			_, found := findEnv(c.Env, name)
+			assert.False(t, found, "expected no %s when monitoring disabled", name)
+		}
+		require.Len(t, c.Ports, 1, "only API port when monitoring disabled")
+	})
+
+	t.Run("custom metrics port", func(t *testing.T) {
+		port := int32(9999)
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+				Monitoring:   &ogxiov1beta1.MonitoringSpec{MetricsPort: &port},
+			},
+		}
+		c := buildContainerSpec(t.Context(), nil, instance, "img", nil, nil)
+		v, found := findEnv(c.Env, "OGX_METRICS_PORT")
+		require.True(t, found)
+		assert.Equal(t, "9999", v)
+		require.Len(t, c.Ports, 2)
+		assert.Equal(t, int32(9999), c.Ports[1].ContainerPort)
+	})
+
+	t.Run("user override of metrics host", func(t *testing.T) {
+		instance := &ogxiov1beta1.OGXServer{
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "x:latest"},
+				Workload: &ogxiov1beta1.WorkloadSpec{
+					Overrides: &ogxiov1beta1.WorkloadOverrides{
+						Env: []corev1.EnvVar{{Name: "OGX_METRICS_HOST", Value: "127.0.0.1"}},
+					},
+				},
+			},
+		}
+		c := buildContainerSpec(t.Context(), nil, instance, "img", nil, nil)
+		v, found := findEnv(c.Env, "OGX_METRICS_HOST")
+		require.True(t, found)
+		assert.Equal(t, "127.0.0.1", v, "user override should win")
+	})
 }
 
 func TestResolveImage(t *testing.T) {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -85,6 +86,12 @@ func TestMain(m *testing.M) {
 	err = rbacv1.AddToScheme(scheme.Scheme)
 	if err != nil {
 		logf.Log.Error(err, "failed to add rbacv1 scheme")
+		os.Exit(1)
+	}
+
+	err = monitoringv1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		logf.Log.Error(err, "failed to add monitoringv1 scheme")
 		os.Exit(1)
 	}
 

--- a/controllers/testing_support_test.go
+++ b/controllers/testing_support_test.go
@@ -307,7 +307,7 @@ func AssertServiceAndDeploymentPortsAlign(t *testing.T, service *corev1.Service,
 	t.Helper()
 	require.Len(t, service.Spec.Ports, 1, "Service should have exactly one port")
 	require.Len(t, deployment.Spec.Template.Spec.Containers, 1, "Deployment should have exactly one container")
-	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Ports, 1, "Container should have exactly one port")
+	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers[0].Ports, "Container should have at least one port")
 
 	serviceTargetPort := service.Spec.Ports[0].TargetPort.IntVal
 	containerPort := deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort
@@ -357,7 +357,7 @@ func hasMatchingIngressRule(
 func AssertNetworkPolicyAllowsDeploymentPort(t *testing.T, networkPolicy *networkingv1.NetworkPolicy, deployment *appsv1.Deployment, operatorNamespace string) {
 	t.Helper()
 	require.Len(t, deployment.Spec.Template.Spec.Containers, 1, "Deployment should have exactly one container")
-	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Ports, 1, "Container should have exactly one port")
+	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers[0].Ports, "Container should have at least one port")
 	containerPort := deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort
 
 	sameNamespacePredicate := func(peer networkingv1.NetworkPolicyPeer) bool {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.23.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.7
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.82.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.28.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.82.0 h1:Ee6zu4IR/WKYEcYHL4+gbC1A3GAzlHWxSjjMyRVBHYw=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.82.0/go.mod h1:hY5yoQsoIalncoxYqXXCDL5y7f+GGYYlW9Bi2IdU5KY=
 github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=
 github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ogx-ai/ogx-k8s-operator/controllers"
 	"github.com/ogx-ai/ogx-k8s-operator/pkg/cluster"
 	"github.com/ogx-ai/ogx-k8s-operator/pkg/deploy"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"go.uber.org/zap/zapcore"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -63,6 +64,7 @@ func init() { //nolint:gochecknoinits
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(ogxiov1beta1.AddToScheme(scheme))
+	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/pkg/deploy/kustomizer.go
+++ b/pkg/deploy/kustomizer.go
@@ -265,11 +265,22 @@ func applyNetworkPolicyTransformer(resMap *resmap.ResMap, ownerInstance *ogxiov1
 		operatorNS = "ogx-k8s-operator-system"
 	}
 
+	var metricsPort int32
+	monitoring := ownerInstance.Spec.Monitoring
+	if monitoring == nil || monitoring.Enabled == nil || *monitoring.Enabled {
+		if monitoring != nil && monitoring.MetricsPort != nil {
+			metricsPort = *monitoring.MetricsPort
+		} else {
+			metricsPort = 9464
+		}
+	}
+
 	npTransformer := plugins.CreateNetworkPolicyTransformer(plugins.NetworkPolicyTransformerConfig{
 		InstanceName:      ownerInstance.GetName(),
 		ServicePort:       GetServicePort(ownerInstance),
 		OperatorNamespace: operatorNS,
 		NetworkSpec:       ownerInstance.Spec.Network,
+		MetricsPort:       metricsPort,
 	})
 
 	return npTransformer.Transform(*resMap)

--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -171,6 +171,55 @@ metadata:
 		assert.Equal(t, "test-fallback-ns", res.GetNamespace(), "Deployment should have the correct namespace set by plugin")
 	})
 
+	t.Run("should render PrometheusRule and apply name prefix", func(t *testing.T) {
+		fsys := filesys.MakeFsInMemory()
+		require.NoError(t, fsys.MkdirAll(manifestBasePath))
+
+		kustomizationContent := `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - prometheusrule.yaml
+`
+		require.NoError(t, fsys.WriteFile(filepath.Join(manifestBasePath, "kustomization.yaml"), []byte(kustomizationContent)))
+
+		promRuleContent := `
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prometheus-rules
+spec:
+  groups:
+  - name: ogx.rules
+    interval: 60s
+    rules:
+    - record: ogx:api_info
+      labels:
+        api: inference
+      expr: clamp_max(ogx_requests_total{api="inference"}, 1)
+`
+		require.NoError(t, fsys.WriteFile(filepath.Join(manifestBasePath, "prometheusrule.yaml"), []byte(promRuleContent)))
+
+		owner := &ogxiov1beta1.OGXServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-ogx",
+				Namespace: "test-prom-ns",
+			},
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "test-image:latest"},
+			},
+		}
+
+		resMap, err := RenderManifest(fsys, manifestBasePath, owner)
+		require.NoError(t, err)
+		require.Equal(t, 1, (*resMap).Size())
+
+		res := (*resMap).Resources()[0]
+		require.Equal(t, "PrometheusRule", res.GetKind())
+		require.Equal(t, "my-ogx-prometheus-rules", res.GetName())
+		assert.Equal(t, "test-prom-ns", res.GetNamespace())
+	})
+
 	t.Run("should return an error if a resource file is missing", func(t *testing.T) {
 		// given a kustomization.yaml that references a file that does not exist
 		fsys := filesys.MakeFsInMemory()
@@ -545,6 +594,20 @@ func TestFilterExcludeKinds(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, (*filtered).Size())
 		require.Equal(t, "Deployment", (*filtered).Resources()[0].GetKind())
+	})
+
+	t.Run("excludes PrometheusRule kind", func(t *testing.T) {
+		promRule := newTestResource(t, "monitoring.coreos.com/v1", "PrometheusRule", "test-rules", "test-ns", nil)
+		svc := newTestResource(t, "v1", "Service", "test-svc", "test-ns", nil)
+
+		resMap := resmap.New()
+		require.NoError(t, resMap.Append(promRule))
+		require.NoError(t, resMap.Append(svc))
+
+		filtered, err := FilterExcludeKinds(&resMap, []string{"PrometheusRule"})
+		require.NoError(t, err)
+		require.Equal(t, 1, (*filtered).Size())
+		require.Equal(t, "Service", (*filtered).Resources()[0].GetKind())
 	})
 }
 

--- a/pkg/deploy/plugins/networkpolicy_transformer.go
+++ b/pkg/deploy/plugins/networkpolicy_transformer.go
@@ -35,6 +35,7 @@ const (
 	// Allow traffic from OpenShift router namespaces.
 	openShiftIngressPolicyGroupLabelKey   = "network.openshift.io/policy-group"
 	openShiftIngressPolicyGroupLabelValue = "ingress"
+	openShiftMonitoringPolicyGroupValue   = "monitoring"
 )
 
 // NetworkPolicyTransformerConfig holds the configuration for the NetworkPolicy transformer.
@@ -47,6 +48,8 @@ type NetworkPolicyTransformerConfig struct {
 	OperatorNamespace string
 	// NetworkSpec is the network configuration from the CR spec.
 	NetworkSpec *ogxiov1beta1.NetworkSpec
+	// MetricsPort is the port for Prometheus scraping. 0 means monitoring is disabled.
+	MetricsPort int32
 }
 
 // CreateNetworkPolicyTransformer creates a transformer for NetworkPolicy resources.
@@ -180,12 +183,14 @@ func (t *networkPolicyTransformer) buildIngressRules() []any {
 		},
 	}
 
-	return []any{
-		map[string]any{
-			"from":  peers,
-			"ports": portRule,
-		},
-	}
+	monitoringRules := t.buildMonitoringIngressRules()
+	rules := make([]any, 0, 1+len(monitoringRules))
+	rules = append(rules, map[string]any{
+		"from":  peers,
+		"ports": portRule,
+	})
+	rules = append(rules, monitoringRules...)
+	return rules
 }
 
 func (t *networkPolicyTransformer) buildPeers() []any {
@@ -226,6 +231,33 @@ func (t *networkPolicyTransformer) buildRouterPeers() []any {
 			"namespaceSelector": map[string]any{
 				"matchLabels": map[string]any{
 					openShiftIngressPolicyGroupLabelKey: openShiftIngressPolicyGroupLabelValue,
+				},
+			},
+		},
+	}
+}
+
+// buildMonitoringIngressRules adds an ingress rule allowing Prometheus scraping on the metrics port.
+func (t *networkPolicyTransformer) buildMonitoringIngressRules() []any {
+	if t.config.MetricsPort == 0 {
+		return nil
+	}
+
+	return []any{
+		map[string]any{
+			"from": []any{
+				map[string]any{
+					"namespaceSelector": map[string]any{
+						"matchLabels": map[string]any{
+							openShiftIngressPolicyGroupLabelKey: openShiftMonitoringPolicyGroupValue,
+						},
+					},
+				},
+			},
+			"ports": []any{
+				map[string]any{
+					"protocol": "TCP",
+					"port":     t.config.MetricsPort,
 				},
 			},
 		},

--- a/pkg/deploy/plugins/networkpolicy_transformer_test.go
+++ b/pkg/deploy/plugins/networkpolicy_transformer_test.go
@@ -209,3 +209,60 @@ func TestNetworkPolicyTransformer_NoRouterPeersWhenNetworkSpecNil(t *testing.T) 
 	// Should NOT have OpenShift router namespace selector when network spec is nil
 	assert.NotContains(t, yamlStr, "network.openshift.io/policy-group: ingress")
 }
+
+func TestNetworkPolicyTransformer_MonitoringIngressWhenMetricsPortSet(t *testing.T) {
+	rf := resource.NewFactory(nil)
+	res, err := rf.FromBytes([]byte(networkPolicyTestYAML))
+	require.NoError(t, err)
+
+	rm := resmap.New()
+	require.NoError(t, rm.Append(res))
+
+	transformer := CreateNetworkPolicyTransformer(NetworkPolicyTransformerConfig{
+		InstanceName:      "test-instance",
+		ServicePort:       8321,
+		OperatorNamespace: "operator-ns",
+		NetworkSpec:       nil,
+		MetricsPort:       9464,
+	})
+
+	err = transformer.Transform(rm)
+	require.NoError(t, err)
+
+	transformedRes := rm.Resources()[0]
+	yamlBytes, err := transformedRes.AsYAML()
+	require.NoError(t, err)
+
+	yamlStr := string(yamlBytes)
+
+	assert.Contains(t, yamlStr, "network.openshift.io/policy-group: monitoring")
+	assert.Contains(t, yamlStr, "port: 9464")
+}
+
+func TestNetworkPolicyTransformer_NoMonitoringIngressWhenMetricsPortZero(t *testing.T) {
+	rf := resource.NewFactory(nil)
+	res, err := rf.FromBytes([]byte(networkPolicyTestYAML))
+	require.NoError(t, err)
+
+	rm := resmap.New()
+	require.NoError(t, rm.Append(res))
+
+	transformer := CreateNetworkPolicyTransformer(NetworkPolicyTransformerConfig{
+		InstanceName:      "test-instance",
+		ServicePort:       8321,
+		OperatorNamespace: "operator-ns",
+		NetworkSpec:       nil,
+		MetricsPort:       0,
+	})
+
+	err = transformer.Transform(rm)
+	require.NoError(t, err)
+
+	transformedRes := rm.Resources()[0]
+	yamlBytes, err := transformedRes.AsYAML()
+	require.NoError(t, err)
+
+	yamlStr := string(yamlBytes)
+
+	assert.NotContains(t, yamlStr, "network.openshift.io/policy-group: monitoring")
+}


### PR DESCRIPTION
Add monitoring resource support to the operator:

- ServiceMonitor targeting metrics port 9464 with 60s scrape interval
- PrometheusRule with ogx:api_info recording rules for the Telemeter pipeline (inference, vector_io, responses, rag, agentic), aggregated via sum() to strip high-cardinality labels, within the ~10 timeseries budget
- NetworkPolicy ingress rule allowing Prometheus scraping from openshift-monitoring namespace on the metrics port
- Metrics endpoint env var injection (OGX_METRICS_ENDPOINT_ENABLED, OGX_METRICS_HOST, OGX_METRICS_PORT) and container port configuration
- Conditional gating on MonitoringCRDsAvailable for both resources