### PR TITLE
test: add monitoring configuration and ServiceMonitor render tests

### DIFF
--- a/controllers/ogxserver_controller_test.go
+++ b/controllers/ogxserver_controller_test.go
@@ -12,6 +12,7 @@ import (
 	ogxiov1beta1 "github.com/ogx-ai/ogx-k8s-operator/api/v1beta1"
 	controllers "github.com/ogx-ai/ogx-k8s-operator/controllers"
 	"github.com/ogx-ai/ogx-k8s-operator/pkg/cluster"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -584,6 +585,94 @@ func TestNetworkPolicyConfiguration(t *testing.T) {
 
 			npKey := types.NamespacedName{Name: instance.Name + "-network-policy", Namespace: instance.Namespace}
 			AssertNetworkPolicyAbsent(t, k8sClient, npKey)
+		})
+	}
+}
+
+func TestMonitoringConfiguration(t *testing.T) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	tests := []struct {
+		name             string
+		monitoring       *ogxiov1beta1.MonitoringSpec
+		expectMetricsEnv bool
+		expectedPort     string
+	}{
+		{
+			name:             "monitoring nil defaults to enabled",
+			monitoring:       nil,
+			expectMetricsEnv: true,
+			expectedPort:     "9464",
+		},
+		{
+			name:             "monitoring explicitly enabled",
+			monitoring:       &ogxiov1beta1.MonitoringSpec{Enabled: boolPtr(true)},
+			expectMetricsEnv: true,
+			expectedPort:     "9464",
+		},
+		{
+			name:             "monitoring disabled",
+			monitoring:       &ogxiov1beta1.MonitoringSpec{Enabled: boolPtr(false)},
+			expectMetricsEnv: false,
+		},
+		{
+			name: "custom metrics port",
+			monitoring: func() *ogxiov1beta1.MonitoringSpec {
+				port := int32(9090)
+				return &ogxiov1beta1.MonitoringSpec{MetricsPort: &port}
+			}(),
+			expectMetricsEnv: true,
+			expectedPort:     "9090",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := createTestNamespace(t, "test-monitoring")
+			instance := NewOGXServerBuilder().
+				WithName(fmt.Sprintf("mon-%d", i)).
+				WithNamespace(namespace.Name).
+				WithDistribution("starter").
+				WithMonitoring(tt.monitoring).
+				Build()
+			require.NoError(t, k8sClient.Create(t.Context(), instance))
+			t.Cleanup(func() { _ = k8sClient.Delete(t.Context(), instance) })
+
+			ReconcileOGXServer(t, instance)
+
+			deployment := &appsv1.Deployment{}
+			waitForResource(t, k8sClient, instance.Namespace, instance.Name, deployment)
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+			envMap := make(map[string]string)
+			for _, e := range container.Env {
+				envMap[e.Name] = e.Value
+			}
+
+			if tt.expectMetricsEnv {
+				assert.Equal(t, "1", envMap["OGX_METRICS_ENDPOINT_ENABLED"],
+					"metrics endpoint should be enabled")
+				assert.Equal(t, "0.0.0.0", envMap["OGX_METRICS_HOST"],
+					"metrics host should be 0.0.0.0")
+				assert.Equal(t, tt.expectedPort, envMap["OGX_METRICS_PORT"],
+					"metrics port should match expected")
+
+				hasMetricsPort := false
+				for _, p := range container.Ports {
+					if p.Name == "metrics" {
+						hasMetricsPort = true
+						break
+					}
+				}
+				assert.True(t, hasMetricsPort, "container should have metrics port")
+			} else {
+				_, hasMetricsEnabled := envMap["OGX_METRICS_ENDPOINT_ENABLED"]
+				assert.False(t, hasMetricsEnabled,
+					"metrics env vars should not be set when monitoring is disabled")
+
+				assert.Len(t, container.Ports, 1,
+					"only API port should exist when monitoring is disabled")
+			}
 		})
 	}
 }

--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -220,6 +220,64 @@ spec:
 		assert.Equal(t, "test-prom-ns", res.GetNamespace())
 	})
 
+	t.Run("should render ServiceMonitor and apply name prefix", func(t *testing.T) {
+		fsys := filesys.MakeFsInMemory()
+		require.NoError(t, fsys.MkdirAll(manifestBasePath))
+
+		kustomizationContent := `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - servicemonitor.yaml
+`
+		require.NoError(t, fsys.WriteFile(filepath.Join(manifestBasePath, "kustomization.yaml"), []byte(kustomizationContent)))
+
+		smContent := `
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: service-monitor
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: ogx-operator
+      app.kubernetes.io/part-of: ogx
+  endpoints:
+  - targetPort: 9464
+    path: /v1/metrics
+    interval: 60s
+`
+		require.NoError(t, fsys.WriteFile(filepath.Join(manifestBasePath, "servicemonitor.yaml"), []byte(smContent)))
+
+		owner := &ogxiov1beta1.OGXServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-ogx",
+				Namespace: "test-sm-ns",
+			},
+			Spec: ogxiov1beta1.OGXServerSpec{
+				Distribution: ogxiov1beta1.DistributionSpec{Image: "test-image:latest"},
+			},
+		}
+
+		resMap, err := RenderManifest(fsys, manifestBasePath, owner)
+		require.NoError(t, err)
+		require.Equal(t, 1, (*resMap).Size())
+
+		res := (*resMap).Resources()[0]
+		require.Equal(t, "ServiceMonitor", res.GetKind())
+		require.Equal(t, "my-ogx-service-monitor", res.GetName())
+		assert.Equal(t, "test-sm-ns", res.GetNamespace())
+
+		yamlBytes, err := res.AsYAML()
+		require.NoError(t, err)
+		yamlStr := string(yamlBytes)
+		assert.Contains(t, yamlStr, "path: /v1/metrics")
+		assert.Contains(t, yamlStr, "targetPort: 9464")
+		assert.Contains(t, yamlStr, "interval: 60s")
+		assert.Contains(t, yamlStr, "app.kubernetes.io/managed-by: ogx-operator")
+		assert.Contains(t, yamlStr, "app.kubernetes.io/part-of: ogx")
+	})
+
 	t.Run("should return an error if a resource file is missing", func(t *testing.T) {
 		// given a kustomization.yaml that references a file that does not exist
 		fsys := filesys.MakeFsInMemory()


### PR DESCRIPTION
## Summary
- Adds `TestMonitoringConfiguration` controller integration test covering monitoring env vars, container ports, nil/enabled/disabled/custom-port cases
- Adds ServiceMonitor kustomize render test verifying name prefix and namespace application

## Test plan
- [x] `make lint` passes
- [ ] `make test` passes