### PR TITLE
refactor: edits to telemetric related options, cardinality

### DIFF
--- a/controllers/manifests/base/prometheusrule.yaml
+++ b/controllers/manifests/base/prometheusrule.yaml
@@ -4,7 +4,7 @@ metadata:
   name: prometheus-rules
 spec:
   groups:
-  - name: ogx.rules
+  - name: telemetry.rules
     interval: 60s
     rules:
     - record: ogx:api_info
@@ -22,8 +22,8 @@ spec:
     - record: ogx:api_info
       labels:
         api: rag
-      expr: clamp_max(sum(ogx_vector_io_queries_total) or vector(0), 1)
+      expr: clamp_max(sum(ogx_vector_io_documents_retrieved_total) or vector(0), 1)
     - record: ogx:api_info
       labels:
         api: agentic
-      expr: clamp_max(sum(ogx_tool_runtime_invocations_total) or vector(0), 1)
+      expr: clamp_max(sum(ogx_responses_agentic_calls_total) or vector(0), 1)

--- a/controllers/manifests/base/servicemonitor.yaml
+++ b/controllers/manifests/base/servicemonitor.yaml
@@ -8,6 +8,6 @@ spec:
       app.kubernetes.io/managed-by: ogx-operator
       app.kubernetes.io/part-of: ogx
   endpoints:
-  - targetPort: 9464
-    path: /v1/metrics
+  - targetPort: metrics
+    path: /metrics
     interval: 60s

--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -190,7 +190,7 @@ metadata:
   name: prometheus-rules
 spec:
   groups:
-  - name: ogx.rules
+  - name: telemetry.rules
     interval: 60s
     rules:
     - record: ogx:api_info


### PR DESCRIPTION
Edits include:
  - Fix ServiceMonitor scrape path from /v1/metrics to /metrics to match the Prometheus endpoint served by
  `prometheus_client.start_http_server()` on port `9464`
  - Change ServiceMonitor targetPort from hardcoded `9464` to named port metrics so it tracks user-configured `spec.monitoring.metricsPort`
  - Align PrometheusRule with MON-approved design (`RHAIENG-5408`): rename rule group to telemetry.rules, use sum without (instance, pod) to strip
  high-cardinality labels, and correct source metrics for rag (`ogx_vector_io_documents_retrieved_total`) and agentic (`ogx_responses_agentic_calls_total`)

Fixes `RHAIENG-5158` and `RHAIENG-5161` .