### PR TITLE
fix: the inline::transformers provider was removed upstream. 

### DIFF
--- a/config/samples/starter-config-configmap.yaml
+++ b/config/samples/starter-config-configmap.yaml
@@ -102,8 +102,6 @@ data:
         provider_type: inline::sentence-transformers
         config:
           trust_remote_code: false
-      - provider_id: transformers
-        provider_type: inline::transformers
       vector_io:
       - provider_id: faiss
         provider_type: inline::faiss
@@ -306,7 +304,7 @@ data:
         provider_id: sentence-transformers
         model_id: nomic-ai/nomic-embed-text-v1.5
       default_reranker_model:
-        provider_id: transformers
+        provider_id: sentence-transformers
         model_id: Qwen/Qwen3-Reranker-0.6B
       file_search_params:
         header_template: "file_search tool found {num_chunks} chunks:\nBEGIN of file_search tool results.\n"


### PR DESCRIPTION
Updating references to it here to avoid CI failures and when running `make test-e2e`.