### PR TITLE
refactor: telemetry and related tests

### DIFF
--- a/controllers/manifests/base/servicemonitor.yaml
+++ b/controllers/manifests/base/servicemonitor.yaml
@@ -2,6 +2,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: service-monitor
+  labels:
+    monitoring.opendatahub.io/scrape: "true"
 spec:
   selector:
     matchLabels:

--- a/controllers/ogxserver_controller_test.go
+++ b/controllers/ogxserver_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -593,27 +594,31 @@ func TestMonitoringConfiguration(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	tests := []struct {
-		name             string
-		monitoring       *ogxiov1beta1.MonitoringSpec
-		expectMetricsEnv bool
-		expectedPort     string
+		name              string
+		monitoring        *ogxiov1beta1.MonitoringSpec
+		expectMetricsEnv  bool
+		expectedPort      string
+		expectServicePort bool
 	}{
 		{
-			name:             "monitoring nil defaults to enabled",
-			monitoring:       nil,
-			expectMetricsEnv: true,
-			expectedPort:     "9464",
+			name:              "monitoring nil defaults to enabled",
+			monitoring:        nil,
+			expectMetricsEnv:  true,
+			expectedPort:      "9464",
+			expectServicePort: true,
 		},
 		{
-			name:             "monitoring explicitly enabled",
-			monitoring:       &ogxiov1beta1.MonitoringSpec{Enabled: boolPtr(true)},
-			expectMetricsEnv: true,
-			expectedPort:     "9464",
+			name:              "monitoring explicitly enabled",
+			monitoring:        &ogxiov1beta1.MonitoringSpec{Enabled: boolPtr(true)},
+			expectMetricsEnv:  true,
+			expectedPort:      "9464",
+			expectServicePort: true,
 		},
 		{
-			name:             "monitoring disabled",
-			monitoring:       &ogxiov1beta1.MonitoringSpec{Enabled: boolPtr(false)},
-			expectMetricsEnv: false,
+			name:              "monitoring disabled",
+			monitoring:        &ogxiov1beta1.MonitoringSpec{Enabled: boolPtr(false)},
+			expectMetricsEnv:  false,
+			expectServicePort: false,
 		},
 		{
 			name: "custom metrics port",
@@ -621,8 +626,9 @@ func TestMonitoringConfiguration(t *testing.T) {
 				port := int32(9090)
 				return &ogxiov1beta1.MonitoringSpec{MetricsPort: &port}
 			}(),
-			expectMetricsEnv: true,
-			expectedPort:     "9090",
+			expectMetricsEnv:  true,
+			expectedPort:      "9090",
+			expectServicePort: true,
 		},
 	}
 
@@ -672,6 +678,27 @@ func TestMonitoringConfiguration(t *testing.T) {
 
 				assert.Len(t, container.Ports, 1,
 					"only API port should exist when monitoring is disabled")
+			}
+
+			service := &corev1.Service{}
+			waitForResource(t, k8sClient, instance.Namespace, instance.Name+"-service", service)
+
+			if tt.expectServicePort {
+				var metricsServicePort *corev1.ServicePort
+				for idx := range service.Spec.Ports {
+					if service.Spec.Ports[idx].Name == "metrics" {
+						metricsServicePort = &service.Spec.Ports[idx]
+						break
+					}
+				}
+				require.NotNil(t, metricsServicePort,
+					"Service should have a metrics port when monitoring is enabled")
+				expectedMetricsPort, _ := strconv.Atoi(tt.expectedPort)
+				assert.Equal(t, int32(expectedMetricsPort), metricsServicePort.Port,
+					"Service metrics port should match expected")
+			} else {
+				assert.Len(t, service.Spec.Ports, 1,
+					"Service should have only the API port when monitoring is disabled")
 			}
 		})
 	}

--- a/controllers/testing_support_test.go
+++ b/controllers/testing_support_test.go
@@ -299,13 +299,21 @@ func AssertPVCHasSize(t *testing.T, pvc *corev1.PersistentVolumeClaim, expectedS
 
 func AssertServicePortMatches(t *testing.T, service *corev1.Service, expectedPort corev1.ServicePort) {
 	t.Helper()
-	require.Len(t, service.Spec.Ports, 1, "Service should have exactly one port")
-	require.Equal(t, expectedPort, service.Spec.Ports[0], "Service port should match expected")
+	require.NotEmpty(t, service.Spec.Ports, "Service should have at least one port")
+	var found bool
+	for _, p := range service.Spec.Ports {
+		if p.Name == expectedPort.Name {
+			require.Equal(t, expectedPort, p, "Service port %q should match expected", expectedPort.Name)
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "Service should contain port named %q", expectedPort.Name)
 }
 
 func AssertServiceAndDeploymentPortsAlign(t *testing.T, service *corev1.Service, deployment *appsv1.Deployment) {
 	t.Helper()
-	require.Len(t, service.Spec.Ports, 1, "Service should have exactly one port")
+	require.NotEmpty(t, service.Spec.Ports, "Service should have at least one port")
 	require.Len(t, deployment.Spec.Template.Spec.Containers, 1, "Deployment should have exactly one container")
 	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers[0].Ports, "Container should have at least one port")
 

--- a/pkg/deploy/kustomizer.go
+++ b/pkg/deploy/kustomizer.go
@@ -249,6 +249,10 @@ func applyPlugins(resMap *resmap.ResMap, ownerInstance *ogxiov1beta1.OGXServer) 
 		return fmt.Errorf("failed to apply NetworkPolicy transformer: %w", err)
 	}
 
+	if err := applyServiceTransformer(resMap, ownerInstance); err != nil {
+		return fmt.Errorf("failed to apply Service transformer: %w", err)
+	}
+
 	if isAutoscalingEnabled(ownerInstance) {
 		if err := removeDeploymentReplicas(*resMap); err != nil {
 			return fmt.Errorf("failed to strip replicas for autoscaling: %w", err)
@@ -265,25 +269,25 @@ func applyNetworkPolicyTransformer(resMap *resmap.ResMap, ownerInstance *ogxiov1
 		operatorNS = "ogx-k8s-operator-system"
 	}
 
-	var metricsPort int32
-	monitoring := ownerInstance.Spec.Monitoring
-	if monitoring == nil || monitoring.Enabled == nil || *monitoring.Enabled {
-		if monitoring != nil && monitoring.MetricsPort != nil {
-			metricsPort = *monitoring.MetricsPort
-		} else {
-			metricsPort = 9464
-		}
-	}
-
 	npTransformer := plugins.CreateNetworkPolicyTransformer(plugins.NetworkPolicyTransformerConfig{
 		InstanceName:      ownerInstance.GetName(),
 		ServicePort:       GetServicePort(ownerInstance),
 		OperatorNamespace: operatorNS,
 		NetworkSpec:       ownerInstance.Spec.Network,
-		MetricsPort:       metricsPort,
+		MetricsPort:       getEffectiveMetricsPort(ownerInstance),
 	})
 
 	return npTransformer.Transform(*resMap)
+}
+
+// applyServiceTransformer conditionally adds a metrics port to the Service.
+func applyServiceTransformer(resMap *resmap.ResMap, ownerInstance *ogxiov1beta1.OGXServer) error {
+	svcTransformer := plugins.CreateServiceTransformer(plugins.ServiceTransformerConfig{
+		MetricsPort: getEffectiveMetricsPort(ownerInstance),
+		ServicePort: GetServicePort(ownerInstance),
+	})
+
+	return svcTransformer.Transform(*resMap)
 }
 
 // removeDeploymentReplicas deletes spec.replicas from Deployment manifests so that

--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -237,14 +237,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: service-monitor
+  labels:
+    monitoring.opendatahub.io/scrape: "true"
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: ogx-operator
       app.kubernetes.io/part-of: ogx
   endpoints:
-  - targetPort: 9464
-    path: /v1/metrics
+  - targetPort: metrics
+    path: /metrics
     interval: 60s
 `
 		require.NoError(t, fsys.WriteFile(filepath.Join(manifestBasePath, "servicemonitor.yaml"), []byte(smContent)))
@@ -271,8 +273,9 @@ spec:
 		yamlBytes, err := res.AsYAML()
 		require.NoError(t, err)
 		yamlStr := string(yamlBytes)
-		assert.Contains(t, yamlStr, "path: /v1/metrics")
-		assert.Contains(t, yamlStr, "targetPort: 9464")
+		assert.Contains(t, yamlStr, "path: /metrics")
+		assert.Contains(t, yamlStr, "targetPort: metrics")
+		assert.Contains(t, yamlStr, "monitoring.opendatahub.io/scrape: \"true\"")
 		assert.Contains(t, yamlStr, "interval: 60s")
 		assert.Contains(t, yamlStr, "app.kubernetes.io/managed-by: ogx-operator")
 		assert.Contains(t, yamlStr, "app.kubernetes.io/part-of: ogx")

--- a/pkg/deploy/plugins/service_transformer.go
+++ b/pkg/deploy/plugins/service_transformer.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/yaml"
+)
+
+const serviceKind = "Service"
+
+// ServiceTransformerConfig holds the configuration for the Service transformer.
+type ServiceTransformerConfig struct {
+	// MetricsPort is the port for Prometheus scraping. 0 means monitoring is disabled.
+	MetricsPort int32
+	// ServicePort is the main API service port.
+	ServicePort int32
+}
+
+// CreateServiceTransformer creates a transformer for Service resources.
+func CreateServiceTransformer(config ServiceTransformerConfig) *serviceTransformer {
+	return &serviceTransformer{config: config}
+}
+
+type serviceTransformer struct {
+	config ServiceTransformerConfig
+}
+
+// Transform applies the Service transformation, conditionally adding a metrics port.
+func (t *serviceTransformer) Transform(m resmap.ResMap) error {
+	if t.config.MetricsPort == 0 || t.config.MetricsPort == t.config.ServicePort {
+		return nil
+	}
+
+	for _, res := range m.Resources() {
+		if res.GetKind() != serviceKind {
+			continue
+		}
+
+		yamlBytes, err := res.AsYAML()
+		if err != nil {
+			return fmt.Errorf("failed to get Service YAML: %w", err)
+		}
+
+		var data map[string]any
+		if err := yaml.Unmarshal(yamlBytes, &data); err != nil {
+			return fmt.Errorf("failed to unmarshal Service YAML: %w", err)
+		}
+
+		spec, ok := data["spec"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		ports, ok := spec["ports"].([]any)
+		if !ok {
+			continue
+		}
+
+		ports = append(ports, map[string]any{
+			"name":       "metrics",
+			"protocol":   "TCP",
+			"port":       t.config.MetricsPort,
+			"targetPort": t.config.MetricsPort,
+		})
+		spec["ports"] = ports
+
+		if err := updateResource(res, data); err != nil {
+			return fmt.Errorf("failed to update Service resource: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Config implements the resmap.TransformerPlugin interface.
+func (t *serviceTransformer) Config(_ *resmap.PluginHelpers, _ []byte) error {
+	return nil
+}

--- a/pkg/deploy/plugins/service_transformer_test.go
+++ b/pkg/deploy/plugins/service_transformer_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
+)
+
+const serviceTestYAML = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    protocol: TCP
+    port: 8321
+    targetPort: 8321
+`
+
+func TestServiceTransformer_AddsMetricsPortWhenDifferentFromServicePort(t *testing.T) {
+	rf := resource.NewFactory(nil)
+	res, err := rf.FromBytes([]byte(serviceTestYAML))
+	require.NoError(t, err)
+
+	rm := resmap.New()
+	require.NoError(t, rm.Append(res))
+
+	transformer := CreateServiceTransformer(ServiceTransformerConfig{
+		MetricsPort: 9464,
+		ServicePort: 8321,
+	})
+
+	err = transformer.Transform(rm)
+	require.NoError(t, err)
+
+	transformedRes := rm.Resources()[0]
+	yamlBytes, err := transformedRes.AsYAML()
+	require.NoError(t, err)
+
+	yamlStr := string(yamlBytes)
+
+	assert.Contains(t, yamlStr, "name: metrics")
+	assert.Contains(t, yamlStr, "port: 9464")
+	assert.Contains(t, yamlStr, "name: http")
+}
+
+func TestServiceTransformer_NoMetricsPortWhenEqualToServicePort(t *testing.T) {
+	rf := resource.NewFactory(nil)
+	res, err := rf.FromBytes([]byte(serviceTestYAML))
+	require.NoError(t, err)
+
+	rm := resmap.New()
+	require.NoError(t, rm.Append(res))
+
+	transformer := CreateServiceTransformer(ServiceTransformerConfig{
+		MetricsPort: 8321,
+		ServicePort: 8321,
+	})
+
+	err = transformer.Transform(rm)
+	require.NoError(t, err)
+
+	transformedRes := rm.Resources()[0]
+	yamlBytes, err := transformedRes.AsYAML()
+	require.NoError(t, err)
+
+	yamlStr := string(yamlBytes)
+
+	assert.NotContains(t, yamlStr, "name: metrics")
+}
+
+func TestServiceTransformer_NoMetricsPortWhenMonitoringDisabled(t *testing.T) {
+	rf := resource.NewFactory(nil)
+	res, err := rf.FromBytes([]byte(serviceTestYAML))
+	require.NoError(t, err)
+
+	rm := resmap.New()
+	require.NoError(t, rm.Append(res))
+
+	transformer := CreateServiceTransformer(ServiceTransformerConfig{
+		MetricsPort: 0,
+		ServicePort: 8321,
+	})
+
+	err = transformer.Transform(rm)
+	require.NoError(t, err)
+
+	transformedRes := rm.Resources()[0]
+	yamlBytes, err := transformedRes.AsYAML()
+	require.NoError(t, err)
+
+	yamlStr := string(yamlBytes)
+
+	assert.NotContains(t, yamlStr, "name: metrics")
+}
+
+func TestServiceTransformer_CustomMetricsPort(t *testing.T) {
+	rf := resource.NewFactory(nil)
+	res, err := rf.FromBytes([]byte(serviceTestYAML))
+	require.NoError(t, err)
+
+	rm := resmap.New()
+	require.NoError(t, rm.Append(res))
+
+	transformer := CreateServiceTransformer(ServiceTransformerConfig{
+		MetricsPort: 9090,
+		ServicePort: 8321,
+	})
+
+	err = transformer.Transform(rm)
+	require.NoError(t, err)
+
+	transformedRes := rm.Resources()[0]
+	yamlBytes, err := transformedRes.AsYAML()
+	require.NoError(t, err)
+
+	yamlStr := string(yamlBytes)
+
+	assert.Contains(t, yamlStr, "name: metrics")
+	assert.Contains(t, yamlStr, "port: 9090")
+}

--- a/pkg/deploy/utils.go
+++ b/pkg/deploy/utils.go
@@ -27,6 +27,19 @@ func GetServiceName(instance *ogxiov1beta1.OGXServer) string {
 	return fmt.Sprintf("%s-service", instance.Name)
 }
 
+const defaultMetricsPort = int32(9464)
+
+func getEffectiveMetricsPort(instance *ogxiov1beta1.OGXServer) int32 {
+	monitoring := instance.Spec.Monitoring
+	if monitoring != nil && monitoring.Enabled != nil && !*monitoring.Enabled {
+		return 0
+	}
+	if monitoring != nil && monitoring.MetricsPort != nil {
+		return *monitoring.MetricsPort
+	}
+	return defaultMetricsPort
+}
+
 // GetEffectiveReplicas returns the desired replica count, defaulting to 1.
 func GetEffectiveReplicas(instance *ogxiov1beta1.OGXServer) int32 {
 	if instance.Spec.Workload != nil && instance.Spec.Workload.Replicas != nil {


### PR DESCRIPTION
Follow-up items for #326, adding `ServiceMonitor` labels, tests, and targeting the metrics port.

Closes RHAIENG-5409.